### PR TITLE
Exposing JSON object on JXContext

### DIFF
--- a/Sources/JXKit/JXContext.swift
+++ b/Sources/JXKit/JXContext.swift
@@ -293,7 +293,7 @@ extension JXContext {
         JXValue(symbol: String(value), in: self)
     }
 
-    /// Creates a new string with the given value in the context.
+    /// Creates a new javascriprt object in this context from the passed JSON string.
     @inlinable public func json<S: StringProtocol>(_ value: S) -> JXValue {
         JXValue(json: String(value), in: self) ?? undefined()
     }

--- a/Sources/JXKit/JXContext.swift
+++ b/Sources/JXKit/JXContext.swift
@@ -293,6 +293,11 @@ extension JXContext {
         JXValue(symbol: String(value), in: self)
     }
 
+    /// Creates a new string with the given value in the context.
+    @inlinable public func json<S: StringProtocol>(_ value: S) -> JXValue {
+        JXValue(json: String(value), in: self) ?? undefined()
+    }
+
     /// Creates a new object in this context and assigns it the given peer object.
     @inlinable public func object(peer: AnyObject? = nil) -> JXValue {
         guard let peer = peer else {

--- a/Tests/JXKitTests/JXCoreTests.swift
+++ b/Tests/JXKitTests/JXCoreTests.swift
@@ -152,6 +152,17 @@ class JXCoreTests: XCTestCase {
         //XCTAssertEqual(try jxc.global[symbol: obj][symbol: container].numberValue, 3)
     }
 
+    func testJSONObject() throws {
+        let jxc = JXContext()
+        let obj = jxc.json(#"""
+        {
+            "abc": "def"
+        }
+        """#)
+        XCTAssertTrue(obj.isObject)
+        XCTAssertEqual(try obj.toJSON(), #"{"abc":"def"}"#)
+    }
+
     func testArrayBuffer() throws {
         let jxc = JXContext()
         


### PR DESCRIPTION
This PR adds a `JXContext.json(_:)` func which takes a JSON string and returns a javascript object `JXValue`. Its primary use is transating JSON into objects rather than strings. This supports getting an object from the javascript context, converting it to a Swift type via JSON, then converting back to a javascript object via JSON. This is to support situations where the type being read and written to the javascript context is unknown.

I have also written a unit test for it, but I'm not sure if it fits within the style of tests as I could not see any obvious tests in this area. 