### PR TITLE
JXKit code suggestions.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let targets: [Target] = [
             .linkedLibrary("ASL", .when(platforms: [.windows])),
         ])
 ]
-#else // no native JavaScriptCore falls back to javascriptcoregtk
+#else // No native JavaScriptCore falls back to javascriptcoregtk
 let targets: [Target] = [
     .systemLibrary(name: "CJSCore", 
         pkgConfig: "javascriptcoregtk-4.0", 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Browse the [API Documentation].
 Functions can be accessed (and cached) to be invoked directly with codable arguments:
 
 ```swift
-let ctx = JXContext()
-let hypot = try ctx.global["Math"]["hypot"]
+let context = JXContext()
+let hypot = try context.global["Math"]["hypot"]
 assert(hypot.isFunction == true)
-let result = try hypot.call(withArguments: try [ctx.encode(3), ctx.encode(4)])
-let hypotValue = try result.numberValue
+let result = try hypot.call(withArguments: try [context.encode(3), context.encode(4)])
+let hypotValue = try result.double
 assert(hypotValue == 5)
 ```
 
@@ -37,15 +37,15 @@ The above invocation of `Math.hypot` can instead be performed by wrapping the ar
 
 ```swift
 /// An example of invoking `Math.hypot` in a wrapper function that takes an encodable argument and returns a Decodable retult.
-struct AB : Encodable { let a, b: Double }
-struct C : Decodable { let c: Double }
+struct AB: Encodable { let a, b: Double }
+struct C: Decodable { let c: Double }
 
-let ctx = JXContext()
+let context = JXContext()
 
-let hypot = try ctx.eval("(function(args) { return { c: Math.hypot(args.a, args.b) }; })")
+let hypot = try context.eval("(function(args) { return { c: Math.hypot(args.a, args.b) }; })")
 assert(hypot.isFunction == true)
 
-let result: C = try hypot.call(withArguments: [ctx.encode(AB(a: 3, b: 4))]).toDecodable(ofType: C.self)
+let result: C = try hypot.call(withArguments: [context.encode(AB(a: 3, b: 4))]).toDecodable(ofType: C.self)
 assert(result.c == 5)
 ```
 
@@ -68,7 +68,7 @@ import JXKit
 
 let jxc = JXContext()
 let value: JXValue = try jxc.eval("1+2")
-assert(try value.numberValue == 3)
+assert(try value.int == 3)
 ```
 
 ## Installation

--- a/Sources/CJSCore/include/jscore_c.h
+++ b/Sources/CJSCore/include/jscore_c.h
@@ -1,5 +1,4 @@
 #ifndef jscore_c_h
 #define jscore_c_h
 #include <webkitgtk-4.0/JavaScriptCore/JavaScript.h>
-// #include "include/JavaScriptCore/JavaScript.h" // TODO: include JSC sources
 #endif

--- a/Sources/JXKit/JXContext.swift
+++ b/Sources/JXKit/JXContext.swift
@@ -1,6 +1,3 @@
-//
-//  JavaScript execution context
-//
 import Foundation
 #if canImport(JavaScriptCore)
 import JavaScriptCore
@@ -10,8 +7,6 @@ import CJSCore
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
-
-// MARK: JXContext
 
 /// A JavaScript execution context. This is a cross-platform analogue to the Objective-C `JavaScriptCore.JSContext`.
 ///
@@ -24,7 +19,7 @@ open class JXContext {
     public let strict: Bool
 
     /// The underlying `JSGlobalContextRef` that is wrapped by this context
-    public let context: JSGlobalContextRef
+    public let contextRef: JSGlobalContextRef
 
     private var strictEvaluated: Bool = false
 
@@ -45,79 +40,76 @@ open class JXContext {
     /// Whether we have instantated the peer class in this context or not
     private var peerClassCreated = false
 
-
-    /// Creates `JXContext` with the given `JXVM`.  `JXValue` references may be used interchangably with multiple instances of `JXContext` with the same `JXVM`, but sharing between  separate `JXVM`s will result in undefined behavior.
+    /// Creates `JXContext` with the given `JXVM`. `JXValue` references may be used interchangably with multiple instances of `JXContext` with the same `JXVM`, but sharing between  separate `JXVM`s will result in undefined behavior.
     /// - Parameters:
-    ///   - vm: the shared virtual machine to use; defaults  to creating a new VM per context
-    ///   - strict: whether to evaluate in strict mode
-    public init(virtualMachine vm: JXVM = JXVM(), strict: Bool = true) {
+    ///   - vm: The shared virtual machine to use; defaults  to creating a new VM per context.
+    ///   - strict: Whether to evaluate in strict mode.
+    public init(vm: JXVM = JXVM(), strict: Bool = true) {
         self.vm = vm
-        self.context = JSGlobalContextCreateInGroup(vm.group, nil)
+        self.contextRef = JSGlobalContextCreateInGroup(vm.groupRef, nil)
         self.strict = strict
     }
 
     /// Wraps an existing `JSGlobalContextRef` in a `JXContext`. Address space will be shared between both contexts.
     /// - Parameters:
-    ///   - env: the shared JXContext to use
-    ///   - strict: whether to evaluate in strict mode
-    public init(ctx: JXContext, strict: Bool = true) {
-        self.vm = JXVM(group: JSContextGetGroup(ctx.context))
-        self.context = ctx.context
+    ///   - context: The shared JXContext to use.
+    ///   - strict: Whether to evaluate in strict mode.
+    public init(context: JXContext, strict: Bool = true) {
+        self.vm = JXVM(groupRef: JSContextGetGroup(context.contextRef))
+        self.contextRef = context.contextRef
         self.strict = strict
-        JSGlobalContextRetain(ctx.context)
+        self.spi = context.spi
+        JSGlobalContextRetain(context.contextRef)
     }
 
     deinit {
         if peerClassCreated == true {
             JSClassRelease(peerClass)
         }
-        JSGlobalContextRelease(context)
+        JSGlobalContextRelease(contextRef)
     }
+
+    /// For use by service providers only.
+    public var spi: AnyObject?
 }
 
-public final class JXValueError {
-    public let value: JXValue
-    public let msg: String?
-    
-    public init(value: JXValue) throws {
-        self.value = value
-        self.msg = value.description
-    }
-}
+//~~~ I think I've seen 'JXError', 'JXValueError', and 'JXErrors'. Maybe use more distinct names or document what each one is used for
 
-public enum JXErrors : Error {
-    /// A required resource was missing
+public enum JXErrors: Error {
+    /// A required resource was missing.
     case missingResource(String)
-    /// An evaluation error occurred
+    /// An evaluation error occurred.
     case evaluationErrorString(String)
-    /// An evaluation error occurred
+    /// An evaluation error occurred.
     case evaluationErrorUnknown
-    /// The API call requires a higher system version (e.g., for JS typed array support)
+    /// The API call requires a higher system version (e.g., for JS typed array support).
     case minimumSystemVersion
-    /// Unable to create a new promise
+    /// Unable to create a new promise.
     case cannotCreatePromise
-    /// Unable to create a new array buffer
+    /// Unable to create a new array buffer.
     case cannotCreateArrayBuffer
-    /// An async call is expected to return a promise
+    /// An async call is expected to return a promise.
     case asyncEvalMustReturnPromise
-    /// The promise returned from an async call is not value
+    /// The promise returned from an async call is not value.
     case invalidAsyncPromise
-    /// Attempt to invoke a non-function object
+    /// Attempt to invoke a non-function object.
     case callOnNonFunction
-    /// Attempt to access a property on an instance that is not an object
+    /// Attempt to access a property on an instance that is not an object.
     case propertyAccessNonObject
-    /// Attempt to add to something that is not an array
+    /// Attempt to add to something that is not an array.
     case addToNonArray
     /// This can occur when the bound instance is not retained anywhere.
     case jumpContextInvalid
-    /// Expected an array for conversion
+    /// Expected an array for conversion.
     case valueNotArray
-    /// A synbolic key was attempted to be set, but the value was not a symbol
+    /// Expected a date for conversion.
+    case valueNotDate
+    /// A synbolic key was attempted to be set, but the value was not a symbol.
     case keyNotSymbol
-    /// An object could not be created from the given JSON
+    /// An object could not be created from the given JSON.
     case cannotCreateFromJSON
 
-    /// A conversion to another numic type failed
+    /// A conversion to another numic type failed.
     case invalidNumericConversion(Double)
 }
 
@@ -130,7 +122,7 @@ extension JXContext {
             let script = useStrict.withCString(JSStringCreateWithUTF8CString)
             defer { JSStringRelease(script) }
             let _ = try trying {
-                JSEvaluateScript(context, script, this?.value, nil, 0, $0)
+                JSEvaluateScript(contextRef, script, this?.valueRef, nil, 0, $0)
             }
             strictEvaluated = true
         }
@@ -140,10 +132,10 @@ extension JXContext {
         defer { JSStringRelease(script) }
 
         let result = try trying {
-            JSEvaluateScript(context, script, this?.value, nil, 0, $0)
+            JSEvaluateScript(contextRef, script, this?.valueRef, nil, 0, $0)
         }
 
-        return result.map { JXValue(ctx: self, valueRef: $0) } ?? JXValue(undefinedIn: self)
+        return result.map { JXValue(context: self, valueRef: $0) } ?? JXValue(undefinedIn: self)
     }
 
     /// Asynchronously evaulates the given script.
@@ -173,7 +165,7 @@ extension JXContext {
                 }
 
                 let rejected = JXValue(newFunctionIn: self) { jxc, this, arg in
-                    c.resume(throwing: arg.first.map({ JXError(ctx: jxc, valueRef: $0.value) }) ?? JXErrors.cannotCreatePromise)
+                    c.resume(throwing: arg.first.map({ JXError(context: jxc, valueRef: $0.valueRef) }) ?? JXErrors.cannotCreatePromise)
                     return JXValue(undefinedIn: jxc)
                 }
 
@@ -181,7 +173,7 @@ extension JXContext {
 
                 // then() should return a promise as well
                 if try !presult.isPromise {
-                    // we can't throw here because it could complete the promise multiple times
+                    // We can't throw here because it could complete the promise multiple times
                     throw JXErrors.asyncEvalMustReturnPromise
                 }
             } catch {
@@ -198,7 +190,7 @@ extension JXContext {
     ///   - startingLineNumber: An integer value specifying the script's starting line number in the file located at sourceURL. This is only used when reporting exceptions.
     ///
     /// - Returns: true if the script is syntactically correct; otherwise false.
-    @inlinable public func check(_ script: String, sourceURL URLString: String? = nil, startingLineNumber: Int = 0) throws -> Bool {
+    @inlinable public func checkSyntax(_ script: String, sourceURL URLString: String? = nil, startingLineNumber: Int = 0) throws -> Bool {
 
         let script = script.withCString(JSStringCreateWithUTF8CString)
         defer { JSStringRelease(script) }
@@ -207,7 +199,7 @@ extension JXContext {
         defer { sourceURL.map(JSStringRelease) }
 
         return try trying {
-            JSCheckScriptSyntax(context, script, sourceURL, Int32(startingLineNumber), $0)
+            JSCheckScriptSyntax(contextRef, script, sourceURL, Int32(startingLineNumber), $0)
         }
     }
 
@@ -215,26 +207,24 @@ extension JXContext {
     ///
     /// During JavaScript execution, you are not required to call this function; the JavaScript engine will garbage collect as needed.
     /// JavaScript values created within a context group are automatically destroyed when the last reference to the context group is released.
-    public func garbageCollect() { JSGarbageCollect(context) }
+    public func garbageCollect() { JSGarbageCollect(contextRef) }
 
     /// The global object.
     public var global: JXValue {
-        JXValue(ctx: self, valueRef: JSContextGetGlobalObject(context))
+        JXValue(context: self, valueRef: JSContextGetGlobalObject(contextRef))
     }
 
     /// Invokes the given closure with the bytes without copying
     /// - Parameters:
-    ///   - source: the data to use
-    ///   - block: the block that passes the temporary JXValue wrapping the buffer data
-    /// - Returns: the result of the closure
+    ///   - source: The data to use.
+    ///   - block: The block that passes the temporary JXValue wrapping the buffer data.
+    /// - Returns: The result of the closure.
     public func withArrayBuffer<T>(source: Data, block: (JXValue) throws -> (T)) throws -> T {
         var source = source
         return try source.withUnsafeMutableBytes { bytes in
-            let buffer = try JXValue(newArrayBufferWithBytesNoCopy: bytes,
-                                 deallocator: { _ in
+            let buffer = try JXValue(newArrayBufferWithBytesNoCopy: bytes, deallocator: { _ in
                 //print("buffer deallocated")
-            },
-                                 in: self)
+            }, in: self)
             return try block(buffer)
         }
     }
@@ -324,7 +314,7 @@ extension JXContext {
 
         let info: UnsafeMutablePointer<AnyObject?> = .allocate(capacity: 1)
         info.initialize(to: peer)
-        let value = JXValue(ctx: self, valueRef: JSObjectMake(self.context, peerClass, info))
+        let value = JXValue(context: self, valueRef: JSObjectMake(self.contextRef, peerClass, info))
         return value
     }
 
@@ -332,7 +322,7 @@ extension JXContext {
     @inlinable public func array(_ values: [JXValue]) throws -> JXValue {
         let array = try JXValue(newArrayIn: self)
         for (index, value) in values.enumerated() {
-            try array.setElement(value, at: UInt32(index))
+            try array.setElement(value, at: index)
         }
         return array
     }
@@ -349,9 +339,10 @@ extension JXContext {
         try JXValue(newErrorFromMessage: "\(error)", in: self)
     }
 
-    /// v a ``JXValue`` from the given JSON string.
-    /// - Parameter string: the JSON string to parse
-    /// - Returns: the value if it could be created
+    /// Create a ``JXValue`` from the given JSON string.
+    /// - Parameters:
+    ///   - string: The JSON string to parse.
+    /// - Returns: The value if it could be created.
     @inlinable public func json(_ string: String) throws -> JXValue {
         if let value = JXValue(json: string, in: self) {
             return value
@@ -366,7 +357,7 @@ extension JXContext {
         var errorPointer: JSValueRef?
         let result = try function(&errorPointer)
         if let errorPointer = errorPointer {
-            throw JXError(ctx: self, valueRef: errorPointer)
+            throw JXError(context: self, valueRef: errorPointer)
         } else {
             return result
         }

--- a/Sources/JXKit/JXConvertible.swift
+++ b/Sources/JXKit/JXConvertible.swift
@@ -4,47 +4,48 @@ import Foundation
 ///
 /// In order to export Swift properties to the JS context, the types must conform to ``JXConvertible``.`
 public protocol JXConvertible {
-    /// Converts this value into a JXContext
-    static func makeJX(from value: JXValue) throws -> Self
+    /// Converts a `JXValue` into this type.
+    static func fromJX(_ value: JXValue) throws -> Self
 
-    /// Converts this value into a JXContext
-    func getJX(from context: JXContext) throws -> JXValue
+    /// Converts this value into a JXContext.
+    func toJX(in context: JXContext) throws -> JXValue
 }
 
 
 extension JXValue {
     /// Attempts to convey the given result from the JS environment.
-    /// - Parameter context: the context to use
-    /// - Returns: the conveyed instance
-    public func convey<T : JXConvertible>(to type: T.Type = T.self) throws -> T {
-        try T.makeJX(from: self)
+    /// - Parameters:
+    ///   - context: The context to use.
+    /// - Returns: The conveyed instance.
+    public func convey<T: JXConvertible>(to type: T.Type = T.self) throws -> T {
+        try T.fromJX(self)
     }
 }
 
-/// Default implementation of ``JXConvertible`` will be to encode and decode ``Codable`` instances between Swift & JS
-extension Decodable where Self : JXConvertible {
-    public static func makeJXCodable(from value: JXValue) throws -> Self {
+/// Default implementation of ``JXConvertible`` will be to encode and decode ``Codable`` instances between Swift & JS.
+extension Decodable where Self: JXConvertible {
+    public static func fromJXCodable(_ value: JXValue) throws -> Self {
         try value.toDecodable(ofType: Self.self)
     }
 
-    public static func makeJX(from value: JXValue) throws -> Self {
-        try makeJXCodable(from: value)
+    public static func fromJX(_ value: JXValue) throws -> Self {
+        try fromJX(value)
     }
 }
 
-extension Encodable where Self : JXConvertible {
-    public func getJXCodable(from context: JXContext) throws -> JXValue {
+extension Encodable where Self: JXConvertible {
+    public func toJXCodable(in context: JXContext) throws -> JXValue {
         try context.encode(self)
     }
 
-    public func getJX(from context: JXContext) throws -> JXValue {
-        try getJXCodable(from: context)
+    public func toJX(in context: JXContext) throws -> JXValue {
+        try toJXCodable(in: context)
     }
 }
 
-// we intentionally do not implement Equatable and Hashable to avoid confusion around the semantics of equatability
+// We intentionally do not implement Equatable and Hashable to avoid confusion around the semantics of equatability.
 //
-//extension JXValue : Equatable, Hashable {
+//extension JXValue: Equatable, Hashable {
 //    public static func == (lhs: JXKit.JXValue, rhs: JXKit.JXValue) -> Bool {
 //        lhs.value == rhs.value
 //    }
@@ -54,54 +55,54 @@ extension Encodable where Self : JXConvertible {
 //    }
 //}
 
-extension JXValue : JXConvertible {
-    public static func makeJXConvertible(from value: JXValue) throws -> Self {
+extension JXValue: JXConvertible {
+    public static func fromJXConvertible(_ value: JXValue) throws -> Self {
         guard let value = value as? Self else {
             throw JXErrors.jumpContextInvalid
         }
         return value
     }
 
-    /// Converts this value into a JXContext
-    public func getJXConvertible(from context: JXContext) -> JXValue {
+    /// Converts this value into a JXContext.
+    public func toJXConvertible(in context: JXContext) -> JXValue {
         self
     }
 
 
-    public static func makeJX(from value: JXValue) throws -> Self {
-        try makeJXConvertible(from: value)
+    public static func fromJX(_ value: JXValue) throws -> Self {
+        try fromJXConvertible(value)
     }
 
-    public func getJX(from context: JXContext) -> JXValue {
-        getJXConvertible(from: context)
+    public func toJX(in context: JXContext) -> JXValue {
+        toJXConvertible(in: context)
     }
 
 }
 
-extension Optional : JXConvertible where Wrapped : JXConvertible {
-    public static func makeJXOptional(from value: JXValue) throws -> Self {
+extension Optional: JXConvertible where Wrapped: JXConvertible {
+    public static func fromJXOptional(_ value: JXValue) throws -> Self {
         if value.isNull {
             return .none
         } else {
-            return try Wrapped.makeJX(from: value)
+            return try Wrapped.fromJX(value)
         }
     }
 
-    public func getJXOptional(from context: JXContext) throws -> JXValue {
-        try self?.getJX(from: context) ?? context.null()
+    public func toJXOptional(in context: JXContext) throws -> JXValue {
+        try self?.toJX(in: context) ?? context.null()
     }
 
-    public static func makeJX(from value: JXValue) throws -> Self {
-        try makeJXOptional(from: value)
+    public static func fromJX(_ value: JXValue) throws -> Self {
+        try fromJXOptional(value)
     }
 
-    public func getJX(from context: JXContext) throws -> JXValue {
-        try getJXOptional(from: context)
+    public func toJX(in context: JXContext) throws -> JXValue {
+        try toJXOptional(in: context)
     }
 }
 
-extension Array : JXConvertible where Element : JXConvertible {
-    public static func makeJX(from value: JXValue) throws -> Self {
+extension Array: JXConvertible where Element: JXConvertible {
+    public static func fromJX(_ value: JXValue) throws -> Self {
         guard value.isArray else {
             throw JXErrors.valueNotArray
         }
@@ -109,13 +110,13 @@ extension Array : JXConvertible where Element : JXConvertible {
         let arrayValue = try value.array
 
         return try arrayValue.map({ jx in
-            try Element.makeJX(from: jx)
+            try Element.fromJX(jx)
         })
     }
 
-    public func getJX(from context: JXContext) throws -> JXValue {
+    public func toJX(in context: JXContext) throws -> JXValue {
         try context.array(self.map({ x in
-            try x.getJX(from: context)
+            try x.toJX(in: context)
         }))
     }
 }
@@ -123,9 +124,9 @@ extension Array : JXConvertible where Element : JXConvertible {
 extension JXValue {
     /// Sets a `JXConvertible` in this value object.
     /// - Parameters:
-    ///   - key: the key to set
-    ///   - object: the `JXConvertible` to convert
-    public func set<T : JXConvertible>(_ key: String, convertible object: T) throws {
-        try setProperty(key, object.getJX(from: self.ctx))
+    ///   - key: The key to set.
+    ///   - object: The `JXConvertible` to convert.
+    public func set<T: JXConvertible>(_ key: String, convertible object: T) throws {
+        try setProperty(key, object.toJX(in: self.context))
     }
 }

--- a/Sources/JXKit/JXDefs.swift
+++ b/Sources/JXKit/JXDefs.swift
@@ -1,0 +1,26 @@
+#if canImport(JavaScriptCore)
+import JavaScriptCore
+#else
+import CJSCore
+#endif
+
+#if canImport(MachO)
+// TODO: how to implement this on Linux?
+import func MachO.NSVersionOfRunTimeLibrary
+/// The runtime version of JavaScript core (e.g., `40239623`).
+public let JavaScriptCoreVersion = NSVersionOfRunTimeLibrary("JavaScriptCore")
+#endif
+
+/// The underlying type that represents a value in the JavaScript environment.
+public typealias JXValueRef = JSValueRef
+
+@usableFromInline internal typealias JXContextRef = JSContextRef
+
+/// The underlying type that represents a string in the JavaScript environment.
+@usableFromInline internal typealias JXStringRef = JSStringRef
+
+/// Work-in-progress, simply to highlight a line with a deprecation warning.
+@available(*, deprecated, message: "work-in-progress")
+@usableFromInline internal func wip<T>(_ value: T) -> T { value }
+
+

--- a/Sources/JXKit/JXProperty.swift
+++ b/Sources/JXKit/JXProperty.swift
@@ -1,0 +1,128 @@
+/// A descriptor for property’s definition.
+public struct JXProperty {
+    public let value: JXValue?
+    public let writable: Bool?
+    @usableFromInline internal let _getter: JXValue?
+    @usableFromInline internal let _setter: JXValue?
+    public let getter: ((JXValue) throws -> JXValue)?
+    public let setter: ((JXValue, JXValue) throws -> Void)?
+    public var configurable: Bool? = nil
+    public var enumerable: Bool? = nil
+
+    /// Generic descriptor.
+    ///
+    /// Contains one or both of the keys enumerable or configurable. Use a genetic descriptor to modify the attributes of an existing
+    /// data or accessor property, or to create a new data property.
+    public init() {
+        self.value = nil
+        self.writable = nil
+        self._getter = nil
+        self._setter = nil
+        self.getter = nil
+        self.setter = nil
+    }
+
+    /// Data descriptor.
+    ///
+    /// Contains one or both of the keys value and writable, and optionally also contains the keys enumerable or configurable. Use a
+    /// data descriptor to create or modify the attributes of a data property on an object (replacing any existing accessor property).
+    public init(value: JXValue? = nil, writable: Bool? = nil, configurable: Bool? = nil, enumerable: Bool? = nil) {
+        self.value = value
+        self.writable = writable
+        self._getter = nil
+        self._setter = nil
+        self.getter = nil
+        self.setter = nil
+        self.configurable = configurable
+        self.enumerable = enumerable
+    }
+
+    /// Accessor descriptor.
+    ///
+    /// Contains one or both of the keys get or set, and optionally also contains the keys enumerable or configurable. Use an accessor
+    /// descriptor to create or modify the attributes of an accessor property on an object (replacing any existing data property).
+    ///
+    /// ```
+    /// let desc = JXProperty(
+    ///     getter: { this in this["private_val"] },
+    ///     setter: { this, newValue in this["private_val"] = newValue }
+    /// )
+    /// ```
+    public init(getter: ((JXValue) throws -> JXValue)? = nil, setter: ((JXValue, JXValue) throws -> Void)? = nil, configurable: Bool? = nil, enumerable: Bool? = nil) {
+        self.value = nil
+        self.writable = nil
+        self._getter = nil
+        self._setter = nil
+        self.getter = getter
+        self.setter = setter
+        self.configurable = configurable
+        self.enumerable = enumerable
+    }
+
+    /// Accessor descriptor.
+    ///
+    /// Contains one or both of the keys get or set, and optionally also contains the keys enumerable or configurable. Use an accessor
+    /// descriptor to create or modify the attributes of an accessor property on an object (replacing any existing data property).
+    public init(getter: JXValue? = nil, setter: JXValue? = nil, configurable: Bool? = nil, enumerable: Bool? = nil) throws {
+        precondition(getter?.isFunction != false, "Invalid getter type")
+        precondition(setter?.isFunction != false, "Invalid setter type")
+        self.value = nil
+        self.writable = nil
+        self._getter = getter
+        self._setter = setter
+        self.getter = getter.map { getter in { this in try getter.call(withArguments: [], this: this) } }
+        self.setter = setter.map { setter in { this, newValue in try setter.call(withArguments: [newValue], this: this) } }
+        self.configurable = configurable
+        self.enumerable = enumerable
+    }
+}
+
+extension JXValue {
+
+    /// Defines a property on the JavaScript object value or modifies a property’s definition.
+    ///
+    /// - Parameters:
+    ///   - property: The property's key, which can either be a string or a symbol.
+    ///   - descriptor: The descriptor object.
+    /// - Returns: the key for the property that was defined
+    @inlinable public func defineProperty(_ property: JXValue, _ descriptor: JXProperty) throws {
+        let desc = JXValue(newObjectIn: context)
+
+        if let value = descriptor.value {
+            try desc.setProperty("value", value)
+        }
+
+        if let writable = descriptor.writable {
+            try desc.setProperty("writable", JXValue(bool: writable, in: context))
+        }
+
+        if let getter = descriptor._getter {
+            try desc.setProperty("get", getter)
+        } else if let getter = descriptor.getter {
+            try desc.setProperty("get", JXValue(newFunctionIn: context) { _, this, _ in try getter(this!) })
+        }
+
+        if let setter = descriptor._setter {
+            try desc.setProperty("set", setter)
+        } else if let setter = descriptor.setter {
+            try desc.setProperty("set", JXValue(newFunctionIn: context) { context, this, arguments in
+                try setter(this!, arguments[0])
+                return JXValue(undefinedIn: context)
+            })
+        }
+
+        if let configurable = descriptor.configurable {
+            try desc.setProperty("configurable", JXValue(bool: configurable, in: context))
+        }
+
+        if let enumerable = descriptor.enumerable {
+            try desc.setProperty("enumerable", JXValue(bool: enumerable, in: context))
+        }
+
+        try context.objectPrototype.invokeMethod("defineProperty", withArguments: [self, property, desc])
+    }
+
+    public func propertyDescriptor(_ property: JXValue) throws -> JXValue {
+        try context.objectPrototype.invokeMethod("getOwnPropertyDescriptor", withArguments: [self, property])
+    }
+}

--- a/Sources/JXKit/JXType.swift
+++ b/Sources/JXKit/JXType.swift
@@ -1,0 +1,41 @@
+/// A type of JavaScript instance.
+public enum JXType: Hashable {
+    /// A null value.
+    case null
+    /// An undefined value.
+    case undefined
+    /// A boolean type.
+    case boolean
+    /// A number type.
+    case number
+    /// A date type.
+    case date
+    /// A buffer type
+    case buffer
+    /// A string type.
+    case string
+    /// An array type.
+    case array
+    /// An object type.
+    case object
+    /// An symbol type.
+    case symbol
+    /// A type not enumerated here.
+    case other
+}
+
+extension JXValue {
+    /// The JavaScript type of this value.
+    @inlinable public var type: JXType {
+        if isUndefined { return .undefined }
+        if isNull { return .null }
+        if isBoolean { return .boolean }
+        if isNumber { return .number }
+        if isSymbol { return .symbol }
+        if (try? isDate) == true { return .date }
+        if isString { return .string }
+        if isArray { return .array }
+        if isObject { return .object }
+        return .other
+    }
+}

--- a/Sources/JXKit/JXValue.swift
+++ b/Sources/JXKit/JXValue.swift
@@ -1,6 +1,3 @@
-//
-//  JavaScript values
-//
 import Foundation
 #if canImport(JavaScriptCore)
 import JavaScriptCore
@@ -13,28 +10,28 @@ import FoundationNetworking
 
 /// A JavaScript object.
 ///
-/// This wraps a `JSObjectRef`, and is the equivalent of `JavaScriptCore.JSValue`
+/// This wraps a `JSObjectRef`, and is the equivalent of `JavaScriptCore.JSValue`.
 public class JXValue {
-    public let ctx: JXContext
-    @usableFromInline let value: JXValueRef
+    public let context: JXContext
+    @usableFromInline let valueRef: JXValueRef
 
-    public convenience init(ctx: JXContext, value: JXValue) {
-        self.init(ctx: ctx, valueRef: value.value)
+    public convenience init(context: JXContext, value: JXValue) {
+        self.init(context: context, valueRef: value.valueRef)
     }
 
-    @usableFromInline internal init(ctx: JXContext, valueRef: JXValueRef) {
-        JSValueProtect(ctx.context, valueRef)
-        self.ctx = ctx
-        self.value = valueRef
+    @usableFromInline internal init(context: JXContext, valueRef: JXValueRef) {
+        JSValueProtect(context.contextRef, valueRef)
+        self.context = context
+        self.valueRef = valueRef
     }
 
     deinit {
-        JSValueUnprotect(ctx.context, value)
+        JSValueUnprotect(context.contextRef, valueRef)
     }
 }
 
 /// An error thrown from JavaScript evaluation.
-public class JXError : JXValue, Error, @unchecked Sendable {
+public class JXError: JXValue, Error, @unchecked Sendable {
 }
 
 extension JXValue {
@@ -54,16 +51,16 @@ extension JXValue {
     ///
     /// - Parameters:
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(undefinedIn ctx: JXContext) {
-        self.init(ctx: ctx, valueRef: JSValueMakeUndefined(ctx.context))
+    @usableFromInline internal convenience init(undefinedIn context: JXContext) {
+        self.init(context: context, valueRef: JSValueMakeUndefined(context.contextRef))
     }
 
     /// Creates a JavaScript value of the `null` type.
     ///
     /// - Parameters:
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(nullIn ctx: JXContext) {
-        self.init(ctx: ctx, valueRef: JSValueMakeNull(ctx.context))
+    @usableFromInline internal convenience init(nullIn context: JXContext) {
+        self.init(context: context, valueRef: JSValueMakeNull(context.contextRef))
     }
 
     /// Creates a JavaScript `Boolean` value.
@@ -71,8 +68,8 @@ extension JXValue {
     /// - Parameters:
     ///   - value: The value to assign to the object.
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(bool value: Bool, in ctx: JXContext) {
-        self.init(ctx: ctx, valueRef: JSValueMakeBoolean(ctx.context, value))
+    @usableFromInline internal convenience init(bool value: Bool, in context: JXContext) {
+        self.init(context: context, valueRef: JSValueMakeBoolean(context.contextRef, value))
     }
 
     /// Creates a JavaScript value of the `Number` type.
@@ -80,8 +77,8 @@ extension JXValue {
     /// - Parameters:
     ///   - value: The value to assign to the object.
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(double value: Double, in ctx: JXContext) {
-        self.init(ctx: ctx, valueRef: JSValueMakeNumber(ctx.context, value))
+    @usableFromInline internal convenience init(double value: Double, in context: JXContext) {
+        self.init(context: context, valueRef: JSValueMakeNumber(context.contextRef, value))
     }
 
     /// Creates a JavaScript value of the `String` type.
@@ -89,10 +86,10 @@ extension JXValue {
     /// - Parameters:
     ///   - value: The value to assign to the object.
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(string value: String, in ctx: JXContext) {
+    @usableFromInline internal convenience init(string value: String, in context: JXContext) {
         let value = value.withCString(JSStringCreateWithUTF8CString)
         defer { JSStringRelease(value) }
-        self.init(ctx: ctx, valueRef: JSValueMakeString(ctx.context, value))
+        self.init(context: context, valueRef: JSValueMakeString(context.contextRef, value))
     }
 
     /// Creates a JavaScript value of the `Symbol` type.
@@ -100,10 +97,10 @@ extension JXValue {
     /// - Parameters:
     ///   - value: The value to assign to the object.
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(symbol value: String, in ctx: JXContext) {
+    @usableFromInline internal convenience init(symbol value: String, in context: JXContext) {
         let value = value.withCString(JSStringCreateWithUTF8CString)
         defer { JSStringRelease(value) }
-        self.init(ctx: ctx, valueRef: JSValueMakeSymbol(ctx.context, value))
+        self.init(context: context, valueRef: JSValueMakeSymbol(context.contextRef, value))
     }
 
     /// Creates a JavaScript value of the parsed `JSON`.
@@ -111,13 +108,13 @@ extension JXValue {
     /// - Parameters:
     ///   - value: The JSON value to parse
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init?(json value: String, in ctx: JXContext) {
+    @usableFromInline internal convenience init?(json value: String, in context: JXContext) {
         let value = value.withCString(JSStringCreateWithUTF8CString)
         defer { JSStringRelease(value) }
-        guard let json = JSValueMakeFromJSONString(ctx.context, value) else {
-            return nil // we just return nil since there is no error parameter
+        guard let json = JSValueMakeFromJSONString(context.contextRef, value) else {
+            return nil // We just return nil since there is no error parameter
         }
-        self.init(ctx: ctx, valueRef: json)
+        self.init(context: context, valueRef: json)
     }
 
     /// Creates a JavaScript `Date` object, as if by invoking the built-in `JSObjectMakeDate` constructor.
@@ -125,12 +122,12 @@ extension JXValue {
     /// - Parameters:
     ///   - value: The value to assign to the object.
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(date value: Date, in ctx: JXContext) throws {
-        let arguments = [JXValue(string: JXValue.rfc3339.string(from: value), in: ctx)]
-        let object = try ctx.trying {
-            JSObjectMakeDate(ctx.context, 1, arguments.map { $0.value }, $0)
+    @usableFromInline internal convenience init(date value: Date, in context: JXContext) throws {
+        let arguments = [JXValue(string: JXValue.rfc3339.string(from: value), in: context)]
+        let object = try context.trying {
+            JSObjectMakeDate(context.contextRef, 1, arguments.map { $0.valueRef }, $0)
         }
-        self.init(ctx: ctx, valueRef: object!)
+        self.init(context: context, valueRef: object!)
     }
 
     /// Creates a JavaScript `RegExp` object, as if by invoking the built-in `RegExp` constructor.
@@ -139,12 +136,12 @@ extension JXValue {
     ///   - pattern: The pattern of regular expression.
     ///   - flags: The flags pass to the constructor.
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(newRegularExpressionFromPattern pattern: String, flags: String, in ctx: JXContext) throws {
-        let arguments = [JXValue(string: pattern, in: ctx), JXValue(string: flags, in: ctx)]
-        let object = try ctx.trying {
-            JSObjectMakeRegExp(ctx.context, 2, arguments.map { $0.value }, $0)
+    @usableFromInline internal convenience init(newRegularExpressionFromPattern pattern: String, flags: String, in context: JXContext) throws {
+        let arguments = [JXValue(string: pattern, in: context), JXValue(string: flags, in: context)]
+        let object = try context.trying {
+            JSObjectMakeRegExp(context.contextRef, 2, arguments.map { $0.valueRef }, $0)
         }
-        self.init(ctx: ctx, valueRef: object!)
+        self.init(context: context, valueRef: object!)
     }
 
     /// Creates a JavaScript `Error` object, as if by invoking the built-in `Error` constructor.
@@ -152,20 +149,20 @@ extension JXValue {
     /// - Parameters:
     ///   - message: The error message.
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(newErrorFromMessage message: String, in ctx: JXContext) throws {
-        let arguments = [JXValue(string: message, in: ctx)]
-        let object = try ctx.trying {
-            JSObjectMakeError(ctx.context, arguments.count, arguments.map { $0.value }, $0)
+    @usableFromInline internal convenience init(newErrorFromMessage message: String, in context: JXContext) throws {
+        let arguments = [JXValue(string: message, in: context)]
+        let object = try context.trying {
+            JSObjectMakeError(context.contextRef, arguments.count, arguments.map { $0.valueRef }, $0)
         }
-        self.init(ctx: ctx, valueRef: object!)
+        self.init(context: context, valueRef: object!)
     }
 
     /// Creates a JavaScript `Object`.
     ///
     /// - Parameters:
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(newObjectIn ctx: JXContext) {
-        self.init(ctx: ctx, valueRef: JSObjectMake(ctx.context, nil, nil))
+    @usableFromInline internal convenience init(newObjectIn context: JXContext) {
+        self.init(context: context, valueRef: JSObjectMake(context.contextRef, nil, nil))
     }
 
     /// Creates a JavaScript `Object` with prototype.
@@ -173,23 +170,23 @@ extension JXValue {
     /// - Parameters:
     ///   - context: The execution context to use.
     ///   - prototype: The prototype to be used.
-    @usableFromInline internal convenience init(newObjectIn ctx: JXContext, prototype: JXValue) throws {
-        let obj = try ctx.objectPrototype.invokeMethod("create", withArguments: [prototype])
-        self.init(ctx: ctx, valueRef: obj.value)
+    @usableFromInline internal convenience init(newObjectIn context: JXContext, prototype: JXValue) throws {
+        let obj = try context.objectPrototype.invokeMethod("create", withArguments: [prototype])
+        self.init(context: context, valueRef: obj.valueRef)
     }
 
     /// Creates a JavaScript `Array` object.
     ///
     /// - Parameters:
     ///   - context: The execution context to use.
-    @usableFromInline internal convenience init(newArrayIn ctx: JXContext, values: [JXValue]? = nil) throws {
-        let array = try ctx.trying {
-            JSObjectMakeArray(ctx.context, 0, nil, $0)
+    @usableFromInline internal convenience init(newArrayIn context: JXContext, values: [JXValue]? = nil) throws {
+        let array = try context.trying {
+            JSObjectMakeArray(context.contextRef, 0, nil, $0)
         }
-        self.init(ctx: ctx, valueRef: array!)
+        self.init(context: context, valueRef: array!)
         if let values = values {
             for (index, element) in values.enumerated() {
-                try self.setElement(element, at: UInt32(index))
+                try self.setElement(element, at: index)
             }
         }
     }
@@ -205,20 +202,20 @@ extension JXValue: CustomStringConvertible {
             return "null"
         }
         if self.isBoolean {
-            return "\(self.booleanValue)"
+            return "\(self.bool)"
         }
         if self.isNumber {
-            return ((try? self.numberValue) ?? .nan).description
+            return ((try? self.double) ?? .nan).description
         }
         if self.isString {
-            return (try? self.stringValue) ?? "string"
+            return (try? self.string) ?? "string"
         }
         if (try? self.isError) == true {
-            return (try? self.stringValue) ?? "error"
+            return (try? self.string) ?? "error"
         }
 
-        // better to not invoke a method from `description`
-        //return try! self.invokeMethod("toString", withArguments: []).stringValue!
+        // Better to not invoke a method from `description`
+        //return try! self.invokeMethod("toString", withArguments: []).string!
         
         return "[JXValue]"
     }
@@ -228,11 +225,11 @@ extension JXValue {
     /// Object’s prototype.
     @inlinable public var prototype: JXValue {
         get {
-            let prototype = JSObjectGetPrototype(ctx.context, value)
-            return prototype.map { JXValue(ctx: ctx, valueRef: $0) } ?? JXValue(undefinedIn: ctx)
+            let prototype = JSObjectGetPrototype(context.contextRef, valueRef)
+            return prototype.map { JXValue(context: context, valueRef: $0) } ?? JXValue(undefinedIn: context)
         }
         set {
-            JSObjectSetPrototype(ctx.context, value, newValue.value)
+            JSObjectSetPrototype(context.contextRef, valueRef, newValue.valueRef)
         }
     }
 }
@@ -241,71 +238,76 @@ extension JXValue {
 
     /// Tests whether a JavaScript value’s type is the undefined type.
     @inlinable public var isUndefined: Bool {
-        JSValueIsUndefined(ctx.context, value)
+        JSValueIsUndefined(context.contextRef, valueRef)
     }
 
     /// Tests whether a JavaScript value’s type is the null type.
     @inlinable public var isNull: Bool {
-        JSValueIsNull(ctx.context, value)
+        JSValueIsNull(context.contextRef, valueRef)
+    }
+
+    /// Returns true if the value is either null or undefined.
+    @inlinable public var isNullOrUndefined: Bool {
+        isUndefined || isNull
     }
 
     /// Tests whether a JavaScript value is Boolean.
     @inlinable public var isBoolean: Bool {
-        JSValueIsBoolean(ctx.context, value)
+        JSValueIsBoolean(context.contextRef, valueRef)
     }
 
     /// Tests whether a JavaScript value’s type is the number type.
     @inlinable public var isNumber: Bool {
-        JSValueIsNumber(ctx.context, value)
+        JSValueIsNumber(context.contextRef, valueRef)
     }
 
     /// Tests whether a JavaScript value’s type is the string type.
     @inlinable public var isString: Bool {
-        JSValueIsString(ctx.context, value)
+        JSValueIsString(context.contextRef, valueRef)
     }
 
     /// Tests whether a JavaScript value’s type is the object type.
     @inlinable public var isObject: Bool {
-        JSValueIsObject(ctx.context, value)
+        JSValueIsObject(context.contextRef, valueRef)
     }
 
     /// Tests whether an object can be called as a constructor.
     @inlinable public var isConstructor: Bool {
-        isObject && JSObjectIsConstructor(ctx.context, value)
+        isObject && JSObjectIsConstructor(context.contextRef, valueRef)
     }
 
     /// Tests whether an object can be called as a function.
     @inlinable public var isFunction: Bool {
-        isObject && JSObjectIsFunction(ctx.context, value)
+        isObject && JSObjectIsFunction(context.contextRef, valueRef)
     }
 
     /// Tests whether an object can be called as a function.
     @inlinable public var isSymbol: Bool {
-        JSValueIsSymbol(ctx.context, value)
+        JSValueIsSymbol(context.contextRef, valueRef)
     }
 
     /// Tests whether a JavaScript value’s type is the date type.
     @inlinable public var isDate: Bool {
         get throws {
-            try isInstance(of: ctx.datePrototype)
+            try isInstance(of: context.datePrototype)
         }
     }
 
     @inlinable public var isPromise: Bool {
         get throws {
-            try isInstance(of: ctx.promisePrototype)
+            try isInstance(of: context.promisePrototype)
         }
     }
 
     /// Tests whether a JavaScript value’s type is the array type.
     @inlinable public var isArray: Bool {
-        JSValueIsArray(ctx.context, value)
+        JSValueIsArray(context.contextRef, valueRef)
     }
 
     /// Tests whether a JavaScript value’s type is the error type.
     @inlinable public var isError: Bool {
         get throws {
-            try isInstance(of: ctx.errorPrototype)
+            try isInstance(of: context.errorPrototype)
         }
     }
 }
@@ -317,7 +319,7 @@ extension JXValue {
     /// An object is frozen if and only if it is not extensible, all its properties are non-configurable, and all its data properties (that is, properties which are not accessor properties with getter or setter components) are non-writable.
     @inlinable public var isFrozen: Bool {
         get throws {
-            try ctx.objectPrototype.invokeMethod("isFrozen", withArguments: [self]).booleanValue
+            try context.objectPrototype.invokeMethod("isFrozen", withArguments: [self]).bool
         }
     }
 
@@ -326,7 +328,7 @@ extension JXValue {
     /// Objects are extensible by default: they can have new properties added to them, and their `Prototype` can be re-assigned. An object can be marked as non-extensible using one of ``preventExtensions()`, `seal()`, `freeze()`, or `Reflect.preventExtensions()`.
     @inlinable public var isExtensible: Bool {
         get throws {
-            try ctx.objectPrototype.invokeMethod("isExtensible", withArguments: [self]).booleanValue
+            try context.objectPrototype.invokeMethod("isExtensible", withArguments: [self]).bool
         }
     }
 
@@ -335,7 +337,7 @@ extension JXValue {
     /// Returns true if the object is sealed, otherwise false. An object is sealed if it is not extensible and if all its properties are non-configurable and therefore not removable (but not necessarily non-writable).
     @inlinable public var isSealed: Bool {
         get throws {
-            try ctx.objectPrototype.invokeMethod("isSealed", withArguments: [self]).booleanValue
+            try context.objectPrototype.invokeMethod("isSealed", withArguments: [self]).bool
         }
     }
 
@@ -345,7 +347,7 @@ extension JXValue {
     ///
     /// For data properties of a frozen object, their values cannot be changed since the writable and configurable attributes are set to false. Accessor properties (getters and setters) work the same — the property value returned by the getter may still change, and the setter can still be called without throwing errors when setting the property. Note that values that are objects can still be modified, unless they are also frozen. As an object, an array can be frozen; after doing so, its elements cannot be altered and no elements can be added to or removed from the array.
     @inlinable public func freeze() throws {
-        try ctx.objectPrototype.invokeMethod("freeze", withArguments: [self])
+        try context.objectPrototype.invokeMethod("freeze", withArguments: [self])
     }
 
     /// The Object.preventExtensions() method prevents new properties from ever being added to an object (i.e. prevents future extensions to the object). It also prevents the object's prototype from being re-assigned.
@@ -359,74 +361,100 @@ extension JXValue {
     ///
     /// There is no way to make an object extensible again once it has been made non-extensible.
     @inlinable public func preventExtensions() throws {
-        try ctx.objectPrototype.invokeMethod("preventExtensions", withArguments: [self])
+        try context.objectPrototype.invokeMethod("preventExtensions", withArguments: [self])
     }
 
     /// The Object.seal() method seals an object. Sealing an object prevents extensions and makes existing properties non-configurable. A sealed object has a fixed set of properties: new properties cannot be added, existing properties cannot be removed, their enumerability and configurability cannot be changed, and its prototype cannot be re-assigned. Values of existing properties can still be changed as long as they are writable. seal() returns the same object that was passed in.
     @inlinable public func seal() throws {
-        try ctx.objectPrototype.invokeMethod("seal", withArguments: [self])
+        try context.objectPrototype.invokeMethod("seal", withArguments: [self])
     }
 }
 
 extension JXValue {
 
     /// Returns the JavaScript boolean value.
-    @inlinable public var booleanValue: Bool {
-        JSValueToBoolean(ctx.context, value)
+    @inlinable public var bool: Bool {
+        JSValueToBoolean(context.contextRef, valueRef)
     }
 
     /// Returns the JavaScript number value.
-    @inlinable public var numberValue: Double {
+    @inlinable public var double: Double {
         get throws {
-            //if !JSValueIsNumber(ctx.context, value) { return nil }
-            try ctx.trying {
-                JSValueToNumber(ctx.context, value, $0)
+            try context.trying {
+                JSValueToNumber(context.contextRef, valueRef, $0)
             }
         }
     }
 
-    /// Returns the JavaScript string value.
-    @inlinable public var stringValue: String {
+    /// Returns the JavaScript number value.
+    @inlinable public var float: Float {
         get throws {
-            let str = try ctx.trying {
-                JSValueToStringCopy(ctx.context, value, $0)
+            let dbl = try double
+            return Float(dbl)
+        }
+    }
+
+    /// Returns the JavaScript number value.
+    @inlinable public var int: Int {
+        get throws {
+            let dbl = try double
+            return dbl.isNaN || dbl.isSignalingNaN || dbl.isInfinite == true ? 0 : Int(dbl)
+        }
+    }
+
+    /// Returns the JavaScript number value.
+    @inlinable public var int64: Int64 {
+        get throws {
+            let dbl = try double
+            return dbl.isNaN || dbl.isSignalingNaN || dbl.isInfinite == true ? 0 : Int64(dbl)
+        }
+    }
+
+    /// Returns the JavaScript string value.
+    @inlinable public var string: String {
+        get throws {
+            let str = try context.trying {
+                JSValueToStringCopy(context.contextRef, valueRef, $0)
             }
             defer { str.map(JSStringRelease) }
             return str.map(String.init) ?? ""
         }
     }
 
-    @inlinable public var dateValue: Date? {
+    @inlinable public var date: Date {
         get throws {
-            //try dateValueMS
-            return try dateValueISO
+            //try dateMS
+            return try dateISO
         }
     }
 
     //    /// Returns the JavaScript date value; this works, but loses the time zone
-    //    @inlinable public var dateValueMS: Date? {
+    //    @inlinable public var dateMS: Date? {
     //        if !isDate {
     //            return nil
     //        }
     //        let result = self.invokeMethod("getTime", withArguments: [])
-    //        return result.numberValue.flatMap { Date(timeIntervalSince1970: $0) }
+    //        return result.double.flatMap { Date(timeIntervalSince1970: $0) }
     //    }
 
     /// Returns the JavaScript date value.
-    @inlinable public var dateValueISO: Date? {
+    @inlinable public var dateISO: Date {
         get throws {
             if !(try isDate) {
-                return nil
+                throw JXErrors.valueNotDate
             }
             let result = try invokeMethod("toISOString", withArguments: [])
-            return try JXValue.rfc3339.date(from: result.stringValue)
+            guard let date = try JXValue.rfc3339.date(from: result.string) else {
+                throw JXErrors.valueNotDate
+            }
+            return date
         }
     }
 
     /// Returns the JavaScript array.
     @inlinable public var array: [JXValue] {
         get throws {
-            return try (0..<UInt32(self.count)).map { try self[$0] }
+            return try (0..<self.count).map { try self[$0] }
         }
     }
 
@@ -445,33 +473,31 @@ extension JXValue {
     /// - Parameters:
     ///   - arguments: The arguments pass to the function.
     ///   - this: The object to use as `this`, or `nil` to use the global object as `this`.
-    ///
     /// - Returns: The object that results from calling object as a function
     @discardableResult @inlinable public func call(withArguments arguments: [JXValue] = [], this: JXValue? = nil) throws -> JXValue {
         if !isFunction {
             // we should have already validated that it is a function
             throw JXErrors.callOnNonFunction
         }
-        let result = try ctx.trying {
-            JSObjectCallAsFunction(ctx.context, value, this?.value, arguments.count, arguments.isEmpty ? nil : arguments.map { $0.value }, $0)
+        let result = try context.trying {
+            JSObjectCallAsFunction(context.contextRef, valueRef, this?.valueRef, arguments.count, arguments.isEmpty ? nil : arguments.map { $0.valueRef }, $0)
         }
         return result.map {
-            let v = JXValue(ctx: ctx, valueRef: $0)
+            let v = JXValue(context: context, valueRef: $0)
             return v
-        } ?? JXValue(undefinedIn: ctx)
+        } ?? JXValue(undefinedIn: context)
     }
 
     /// Calls an object as a constructor.
     ///a
     /// - Parameters:
     ///   - arguments: The arguments pass to the function.
-    ///
     /// - Returns: The object that results from calling object as a constructor.
     @inlinable public func construct(withArguments arguments: [JXValue]) throws -> JXValue {
-        let result = try ctx.trying {
-            JSObjectCallAsConstructor(ctx.context, value, arguments.count, arguments.isEmpty ? nil : arguments.map { $0.value }, $0)
+        let result = try context.trying {
+            JSObjectCallAsConstructor(context.contextRef, valueRef, arguments.count, arguments.isEmpty ? nil : arguments.map { $0.valueRef }, $0)
         }
-        return result.map { JXValue(ctx: ctx, valueRef: $0) } ?? JXValue(undefinedIn: ctx)
+        return result.map { JXValue(context: context, valueRef: $0) } ?? JXValue(undefinedIn: context)
     }
 
     /// Invoke an object's method.
@@ -479,7 +505,6 @@ extension JXValue {
     /// - Parameters:
     ///   - name: The name of method.
     ///   - arguments: The arguments pass to the function.
-    ///
     /// - Returns: The object that results from calling the method.
     @discardableResult
     @inlinable public func invokeMethod(_ name: String, withArguments arguments: [JXValue]) throws -> JXValue {
@@ -493,21 +518,19 @@ extension JXValue {
     ///
     /// - Parameters:
     ///   - other: The other value to be compare.
-    ///
     /// - Returns: true if the two values are strict equal; otherwise false.
     @inlinable public func isEqual(to other: JXValue) -> Bool {
-        JSValueIsStrictEqual(ctx.context, value, other.value)
+        JSValueIsStrictEqual(context.contextRef, valueRef, other.valueRef)
     }
 
     /// Tests whether two JavaScript values are equal, as compared by the JS `==` operator.
     ///
     /// - Parameters:
     ///   - other: The other value to be compare.
-    ///
     /// - Returns: true if the two values are equal; false if they are not equal or an exception is thrown.
     @inlinable public func isEqualWithTypeCoercion(to other: JXValue) throws -> Bool {
-        try ctx.trying {
-            JSValueIsEqual(ctx.context, value, other.value, $0)
+        try context.trying {
+            JSValueIsEqual(context.contextRef, valueRef, other.valueRef, $0)
         }
     }
 
@@ -515,11 +538,10 @@ extension JXValue {
     ///
     /// - Parameters:
     ///   - other: The constructor to test against.
-    ///
     /// - Returns: true if the value is an object constructed by constructor, as compared by the JS isInstance(of:) operator; otherwise false.
     @inlinable public func isInstance(of other: JXValue) throws -> Bool {
-        try ctx.trying {
-            JSValueIsInstanceOfConstructor(ctx.context, value, other.value, $0)
+        try context.trying {
+            JSValueIsInstanceOfConstructor(context.contextRef, valueRef, other.valueRef, $0)
         }
     }
 }
@@ -530,7 +552,7 @@ extension JXValue {
     @inlinable public var properties: [String] {
         if !isObject { return [] }
 
-        let _list = JSObjectCopyPropertyNames(ctx.context, value)
+        let _list = JSObjectCopyPropertyNames(context.contextRef, valueRef)
         defer { JSPropertyNameArrayRelease(_list) }
 
         let count = JSPropertyNameArrayGetCount(_list)
@@ -543,26 +565,24 @@ extension JXValue {
     ///
     /// - Parameters:
     ///   - property: The property's name.
-    ///
     /// - Returns: true if the object has `property`, otherwise false.
     @inlinable public func hasProperty(_ property: String) -> Bool {
         let property = property.withCString(JSStringCreateWithUTF8CString)
         defer { JSStringRelease(property) }
-        return JSObjectHasProperty(ctx.context, value, property)
+        return JSObjectHasProperty(context.contextRef, valueRef, property)
     }
 
     /// Deletes a property from an object.
     ///
     /// - Parameters:
     ///   - property: The property's name.
-    ///
     /// - Returns: true if the delete operation succeeds, otherwise false.
     @discardableResult
     @inlinable public func removeProperty(_ property: String) throws -> Bool {
         let property = property.withCString(JSStringCreateWithUTF8CString)
         defer { JSStringRelease(property) }
-        return try ctx.trying {
-            JSObjectDeleteProperty(ctx.context, value, property, $0)
+        return try context.trying {
+            JSObjectDeleteProperty(context.contextRef, valueRef, property, $0)
         }
     }
 
@@ -570,13 +590,12 @@ extension JXValue {
     ///
     /// - Parameters:
     ///   - property: The property's key (usually a string or number).
-    ///
     /// - Returns: true if a property with the given key exists
     @discardableResult
     @inlinable public func hasProperty(_ property: JXValue) throws -> Bool {
         if !isObject { return false }
-        return try ctx.trying {
-            JSObjectHasPropertyForKey(ctx.context, value, property.value, $0)
+        return try context.trying {
+            JSObjectHasPropertyForKey(context.contextRef, valueRef, property.valueRef, $0)
         }
     }
 
@@ -584,25 +603,24 @@ extension JXValue {
     ///
     /// - Parameters:
     ///   - property: The property's name.
-    ///
     /// - Returns: true if the delete operation succeeds, otherwise false.
     @discardableResult
     @inlinable public func deleteProperty(_ property: JXValue) throws -> Bool {
-        try ctx.trying {
-            JSObjectDeletePropertyForKey(ctx.context, value, property.value, $0)
+        try context.trying {
+            JSObjectDeletePropertyForKey(context.contextRef, valueRef, property.valueRef, $0)
         }
     }
 
     /// The value of the property.
     @inlinable public subscript(propertyName: String) -> JXValue {
         get throws {
-            if !isObject { return ctx.undefined() }
+            if !isObject { return context.undefined() }
             let property = JSStringCreateWithUTF8CString(propertyName)
             defer { JSStringRelease(property) }
-            let result = try ctx.trying {
-                JSObjectGetProperty(ctx.context, value, property, $0)
+            let result = try context.trying {
+                JSObjectGetProperty(context.contextRef, valueRef, property, $0)
             }
-            return result.map { JXValue(ctx: ctx, valueRef: $0) } ?? JXValue(undefinedIn: ctx)
+            return result.map { JXValue(context: context, valueRef: $0) } ?? JXValue(undefinedIn: context)
         }
     }
 
@@ -615,10 +633,10 @@ extension JXValue {
             if !symbol.isSymbol {
                 throw JXErrors.keyNotSymbol
             }
-            let result = try ctx.trying {
-                JSObjectGetPropertyForKey(ctx.context, value, symbol.value, $0)
+            let result = try context.trying {
+                JSObjectGetPropertyForKey(context.contextRef, valueRef, symbol.valueRef, $0)
             }
-            return result.map { JXValue(ctx: ctx, valueRef: $0) } ?? JXValue(undefinedIn: ctx)
+            return result.map { JXValue(context: context, valueRef: $0) } ?? JXValue(undefinedIn: context)
         }
     }
 
@@ -634,8 +652,8 @@ extension JXValue {
 
         let property = JSStringCreateWithUTF8CString(key)
         defer { JSStringRelease(property) }
-        try ctx.trying {
-            JSObjectSetProperty(ctx.context, value, property, newValue.value, 0, $0)
+        try context.trying {
+            JSObjectSetProperty(context.contextRef, valueRef, property, newValue.valueRef, 0, $0)
         }
         return newValue
     }
@@ -644,14 +662,14 @@ extension JXValue {
     /// - Parameters:
     ///   - key: the name of the symbol to use
     ///   - newValue: the value to set the property
-    /// - Returns:
+    /// - Returns: the value itself
     @discardableResult @inlinable public func setProperty(symbol: JXValue, _ newValue: JXValue) throws -> JXValue {
         if !isObject {
             throw JXErrors.propertyAccessNonObject
         }
 
-        try ctx.trying {
-            JSObjectSetPropertyForKey(ctx.context, value, symbol.value, newValue.value, 0, $0)
+        try context.trying {
+            JSObjectSetPropertyForKey(context.contextRef, valueRef, symbol.valueRef, newValue.valueRef, 0, $0)
         }
         return newValue
     }
@@ -661,33 +679,32 @@ extension JXValue {
     /// The length of the object.
     @inlinable public var count: Int {
         get throws {
-            let dbl = try self["length"].numberValue
-            return dbl.isNaN || dbl.isSignalingNaN || dbl.isInfinite == true ? 0 : Int(dbl)
+            return try self["length"].int
         }
     }
 
     /// The value in object at index.
-    @inlinable public subscript(index: UInt32) -> JXValue {
+    @inlinable public subscript(index: Int) -> JXValue {
         get throws {
-            let result = try ctx.trying {
-                JSObjectGetPropertyAtIndex(ctx.context, value, index, $0)
+            let result = try context.trying {
+                JSObjectGetPropertyAtIndex(context.contextRef, valueRef, UInt32(index), $0)
             }
-            return result.map { JXValue(ctx: ctx, valueRef: $0) } ?? JXValue(undefinedIn: ctx)
+            return result.map { JXValue(context: context, valueRef: $0) } ?? JXValue(undefinedIn: context)
         }
     }
 
-    @inlinable public func setElement(_ element: JXValue, at index: UInt32) throws {
-        try ctx.trying {
-            JSObjectSetPropertyAtIndex(ctx.context, value, index, element.value, $0)
+    @inlinable public func setElement(_ element: JXValue, at index: Int) throws {
+        try context.trying {
+            JSObjectSetPropertyAtIndex(context.contextRef, valueRef, UInt32(index), element.valueRef, $0)
         }
     }
 }
 
 extension JXValue {
     /// Returns the JavaScript string with the given indentation. This should be the same as the output of `JSON.stringify`.
-    @inlinable public func toJSON(indent: UInt32 = 0) throws -> String {
-        let str = try ctx.trying {
-            JSValueCreateJSONString(ctx.context, value, indent, $0)
+    @inlinable public func toJSON(indent: Int = 0) throws -> String {
+        let str = try context.trying {
+            JSValueCreateJSONString(context.contextRef, valueRef, UInt32(indent), $0)
         }
         defer { str.map(JSStringRelease) }
         return str.map(String.init) ?? "null"
@@ -701,9 +718,9 @@ extension JXValue {
     /// - Parameters:
     ///   - length: Length of new `ArrayBuffer` object.
     ///   - context: The execution context to use.
-    public convenience init(newArrayBufferWithLength length: Int, in ctx: JXContext) throws {
-        let obj = try ctx.arrayBufferPrototype.construct(withArguments: [JXValue(double: Double(length), in: ctx)])
-        self.init(ctx: ctx, valueRef: obj.value)
+    public convenience init(newArrayBufferWithLength length: Int, in context: JXContext) throws {
+        let obj = try context.arrayBufferPrototype.construct(withArguments: [JXValue(double: Double(length), in: context)])
+        self.init(context: context, valueRef: obj.valueRef)
     }
 
     /// Creates a JavaScript `ArrayBuffer` object.
@@ -712,15 +729,15 @@ extension JXValue {
     ///   - bytes: A buffer to be used as the backing store of the `ArrayBuffer` object.
     ///   - deallocator: The allocator to use to deallocate the external buffer when the `ArrayBuffer` object is deallocated.
     ///   - context: The execution context to use.
-    public convenience init(newArrayBufferWithBytesNoCopy bytes: UnsafeMutableRawBufferPointer, deallocator: @escaping (UnsafeMutableRawBufferPointer) -> Void, in ctx: JXContext) throws {
+    public convenience init(newArrayBufferWithBytesNoCopy bytes: UnsafeMutableRawBufferPointer, deallocator: @escaping (UnsafeMutableRawBufferPointer) -> Void, in context: JXContext) throws {
 
         typealias Deallocator = () -> Void
 
         let info: UnsafeMutablePointer<Deallocator> = .allocate(capacity: 1)
         info.initialize(to: { deallocator(bytes) })
 
-        let value = try ctx.trying {
-            JSObjectMakeArrayBufferWithBytesNoCopy(ctx.context, bytes.baseAddress, bytes.count, { _, info in
+        let value = try context.trying {
+            JSObjectMakeArrayBufferWithBytesNoCopy(context.contextRef, bytes.baseAddress, bytes.count, { _, info in
                 guard let info = info?.assumingMemoryBound(to: Deallocator.self) else { return }
                 info.pointee()
                 info.deinitialize(count: 1).deallocate()
@@ -731,7 +748,7 @@ extension JXValue {
             throw JXErrors.cannotCreateArrayBuffer
         }
 
-        self.init(ctx: ctx, valueRef: value)
+        self.init(context: context, valueRef: value)
     }
 
     /// Creates a JavaScript `ArrayBuffer` object.
@@ -739,18 +756,18 @@ extension JXValue {
     /// - Parameters:
     ///   - bytes: A buffer to copy.
     ///   - context: The execution context to use.
-    public convenience init<S: DataProtocol>(newArrayBufferWithBytes bytes: S, in ctx: JXContext) throws {
+    public convenience init<S: DataProtocol>(newArrayBufferWithBytes bytes: S, in context: JXContext) throws {
 
         let buffer: UnsafeMutableRawPointer = .allocate(byteCount: bytes.count, alignment: MemoryLayout<UInt8>.alignment)
         bytes.copyBytes(to: UnsafeMutableRawBufferPointer(start: buffer, count: bytes.count))
 
-        guard let bufValue = try ctx.trying(function: {
-            JSObjectMakeArrayBufferWithBytesNoCopy(ctx.context, buffer, bytes.count, { buffer, _ in buffer?.deallocate() }, nil, $0)
+        guard let bufValue = try context.trying(function: {
+            JSObjectMakeArrayBufferWithBytesNoCopy(context.contextRef, buffer, bytes.count, { buffer, _ in buffer?.deallocate() }, nil, $0)
         }) else {
             throw JXErrors.cannotCreateArrayBuffer
         }
 
-        self.init(ctx: ctx, valueRef: bufValue)
+        self.init(context: context, valueRef: bufValue)
     }
 }
 
@@ -758,14 +775,14 @@ extension JXValue {
     /// Tests whether a JavaScript value’s type is the `ArrayBuffer` type.
     public var isArrayBuffer: Bool {
         get throws {
-            try isInstance(of: ctx.arrayBufferPrototype)
+            try isInstance(of: context.arrayBufferPrototype)
         }
     }
 
     /// The length (in bytes) of the `ArrayBuffer`.
     public var byteLength: Int {
         get throws {
-            let num = try self["byteLength"].numberValue
+            let num = try self["byteLength"].double
             if let int = Int(exactly: num) {
                 return int
             }
@@ -776,11 +793,11 @@ extension JXValue {
     /// Copy the bytes of `ArrayBuffer`.
     public func copyBytes() throws -> Data? {
         guard try self.isArrayBuffer else { return nil }
-        let length = try ctx.trying {
-            JSObjectGetArrayBufferByteLength(ctx.context, value, $0)
+        let length = try context.trying {
+            JSObjectGetArrayBufferByteLength(context.contextRef, valueRef, $0)
         }
-        return try ctx.trying {
-            Data(bytes: JSObjectGetArrayBufferBytesPtr(ctx.context, value, $0), count: length!)
+        return try context.trying {
+            Data(bytes: JSObjectGetArrayBufferBytesPtr(context.contextRef, valueRef, $0), count: length!)
         }
     }
 }
@@ -792,13 +809,8 @@ extension String {
     }
 }
 
-
-// MARK: Functions
-
-
 /// A function definition, used when defining callbacks.
 public typealias JXFunction = (JXContext, JXValue?, [JXValue]) throws -> JXValue
-
 
 extension JXValue {
     /// Creates a JavaScript value of the function type.
@@ -806,11 +818,10 @@ extension JXValue {
     /// - Parameters:
     ///   - context: The execution context to use.
     ///   - callback: The callback function.
-    ///
     /// - Note: This object is callable as a function (due to `JSClassDefinition.callAsFunction`), but the JavaScript runtime doesn't treat it exactly like a function. For example, you cannot call "apply" on it. It could be better to use `JSObjectMakeFunctionWithCallback`, which may act more like a "true" JavaScript function.
-    public convenience init(newFunctionIn ctx: JXContext, callback: @escaping JXFunction) {
+    public convenience init(newFunctionIn context: JXContext, callback: @escaping JXFunction) {
         let info: UnsafeMutablePointer<JXFunctionInfo> = .allocate(capacity: 1)
-        info.initialize(to: JXFunctionInfo(context: ctx, callback: callback))
+        info.initialize(to: JXFunctionInfo(context: context, callback: callback))
 
         var def = JSClassDefinition()
         def.finalize = JXFunctionFinalize
@@ -821,17 +832,17 @@ extension JXValue {
         let _class = JSClassCreate(&def)
         defer { JSClassRelease(_class) }
 
-        // JSObjectMakeFunctionWithCallback(ctx.context, JSStringRef, JSObjectCallAsFunctionCallback)
-        self.init(ctx: ctx, valueRef: JSObjectMake(ctx.context, _class, info))
+        // JSObjectMakeFunctionWithCallback(context.context, JSStringRef, JSObjectCallAsFunctionCallback)
+        self.init(context: context, valueRef: JSObjectMake(context.contextRef, _class, info))
     }
 
-    public static func createPromise(in ctx: JXContext) throws -> JXPromise {
+    public static func createPromise(in context: JXContext) throws -> JXPromise {
         var resolveRef: JSObjectRef?
         var rejectRef: JSObjectRef?
 
         // https://github.com/WebKit/WebKit/blob/b46f54e33e5cb968174e4d20392513e14d04839f/Source/JavaScriptCore/API/JSValue.mm#L158
-        guard let promise = try ctx.trying(function: {
-            JSObjectMakeDeferredPromise(ctx.context, &resolveRef, &rejectRef, $0)
+        guard let promise = try context.trying(function: {
+            JSObjectMakeDeferredPromise(context.contextRef, &resolveRef, &rejectRef, $0)
         }) else {
             throw JXErrors.cannotCreatePromise
         }
@@ -839,34 +850,34 @@ extension JXValue {
         guard let resolve = resolveRef else {
             throw JXErrors.cannotCreatePromise
         }
-        let resolveFunction = JXValue(ctx: ctx, valueRef: resolve)
+        let resolveFunction = JXValue(context: context, valueRef: resolve)
 
         guard let reject = rejectRef else {
             throw JXErrors.cannotCreatePromise
         }
-        let rejectFunction = JXValue(ctx: ctx, valueRef: reject)
+        let rejectFunction = JXValue(context: context, valueRef: reject)
 
-        return (JXValue(ctx: ctx, valueRef: promise), resolveFunction, rejectFunction)
+        return (JXValue(context: context, valueRef: promise), resolveFunction, rejectFunction)
     }
 
     /// Creates a promise and executes it immediately
     /// - Parameters:
-    ///   - ctx: the context to use for creation
-    ///   - executor: the executor callback
-    public convenience init(newPromiseIn ctx: JXContext, executor: (JXContext, _ resolve: JXValue, _ reject: JXValue) throws -> ()) throws {
-        let (promise, resolve, reject) = try Self.createPromise(in: ctx)
-        try executor(ctx, resolve, reject)
-        self.init(ctx: ctx, value: promise)
+    ///   - context: The context to use for creation.
+    ///   - executor: The executor callback.
+    public convenience init(newPromiseIn context: JXContext, executor: (JXContext, _ resolve: JXValue, _ reject: JXValue) throws -> ()) throws {
+        let (promise, resolve, reject) = try Self.createPromise(in: context)
+        try executor(context, resolve, reject)
+        self.init(context: context, value: promise)
     }
 
-    public convenience init(newPromiseResolvedWithResult result: JXValue, in ctx: JXContext) throws {
-        try self.init(newPromiseIn: ctx) { jxc, resolve, reject in
+    public convenience init(newPromiseResolvedWithResult result: JXValue, in context: JXContext) throws {
+        try self.init(newPromiseIn: context) { jxc, resolve, reject in
             try resolve.call(withArguments: [result])
         }
     }
 
-    public convenience init(newPromiseRejectedWithResult reason: JXValue, in ctx: JXContext) throws {
-        try self.init(newPromiseIn: ctx) { jxc, resolve, reject in
+    public convenience init(newPromiseRejectedWithResult reason: JXValue, in context: JXContext) throws {
+        try self.init(newPromiseIn: context) { jxc, resolve, reject in
             try reject.call(withArguments: [reason])
         }
     }
@@ -888,19 +899,19 @@ private func JXFunctionFinalize(_ object: JSObjectRef?) -> Void {
 private func JXFunctionConstructor(_ jxc: JXContextRef?, _ object: JSObjectRef?, _ argumentCount: Int, _ arguments: UnsafePointer<JSValueRef?>?, _ exception: UnsafeMutablePointer<JSValueRef?>?) -> JSObjectRef? {
 
     let info = JSObjectGetPrivate(object).assumingMemoryBound(to: JXFunctionInfo.self)
-    let ctx = info.pointee.context
+    let context = info.pointee.context
 
     do {
-        let arguments = (0..<argumentCount).map { JXValue(ctx: ctx, valueRef: arguments![$0]!) }
-        let result = try info.pointee.callback(ctx, nil, arguments)
+        let arguments = (0..<argumentCount).map { JXValue(context: context, valueRef: arguments![$0]!) }
+        let result = try info.pointee.callback(context, nil, arguments)
 
-        let prototype = JSObjectGetPrototype(ctx.context, object)
-        JSObjectSetPrototype(ctx.context, result.value, prototype)
+        let prototype = JSObjectGetPrototype(context.contextRef, object)
+        JSObjectSetPrototype(context.contextRef, result.valueRef, prototype)
 
-        return result.value
+        return result.valueRef
     } catch let error {
-        let error = (error as? JXValueError)?.value ?? (try? JXValue(newErrorFromMessage: "\(error)", in: ctx))
-        exception?.pointee = error?.value
+        let error = try? JXValue(newErrorFromMessage: "\(error)", in: context)
+        exception?.pointee = error?.valueRef
         return nil
     }
 }
@@ -908,199 +919,27 @@ private func JXFunctionConstructor(_ jxc: JXContextRef?, _ object: JSObjectRef?,
 private func JXFunctionCallback(_ jxc: JXContextRef?, _ object: JSObjectRef?, _ this: JSObjectRef?, _ argumentCount: Int, _ arguments: UnsafePointer<JSValueRef?>?, _ exception: UnsafeMutablePointer<JSValueRef?>?) -> JSValueRef? {
 
     let info = JSObjectGetPrivate(object).assumingMemoryBound(to: JXFunctionInfo.self)
-    let ctx = info.pointee.context
+    let context = info.pointee.context
 
     do {
-        let this = this.map { JXValue(ctx: ctx, valueRef: $0) }
-        let arguments = (0..<argumentCount).map { JXValue(ctx: ctx, valueRef: arguments![$0]!) }
-        let result = try info.pointee.callback(ctx, this, arguments)
-        return result.value
+        let this = this.map { JXValue(context: context, valueRef: $0) }
+        let arguments = (0..<argumentCount).map { JXValue(context: context, valueRef: arguments![$0]!) }
+        let result = try info.pointee.callback(context, this, arguments)
+        return result.valueRef
     } catch let error {
-        let error = (error as? JXValueError)?.value ?? (try? JXValue(newErrorFromMessage: "\(error)", in: ctx))
-        exception?.pointee = error?.value
+        let error = try? JXValue(newErrorFromMessage: "\(error)", in: context)
+        exception?.pointee = error?.valueRef
         return nil
     }
 }
 
 private func JXFunctionInstanceOf(_ jxc: JXContextRef?, _ constructor: JSObjectRef?, _ possibleInstance: JSValueRef?, _ exception: UnsafeMutablePointer<JSValueRef?>?) -> Bool {
     let info = JSObjectGetPrivate(constructor).assumingMemoryBound(to: JXFunctionInfo.self)
-    let ctx = info.pointee.context
-    let pt1 = JSObjectGetPrototype(ctx.context, constructor)
-    let pt2 = JSObjectGetPrototype(ctx.context, possibleInstance)
-    return JSValueIsStrictEqual(ctx.context, pt1, pt2)
+    let context = info.pointee.context
+    let pt1 = JSObjectGetPrototype(context.contextRef, constructor)
+    let pt2 = JSObjectGetPrototype(context.contextRef, possibleInstance)
+    return JSValueIsStrictEqual(context.contextRef, pt1, pt2)
 }
-
-
-extension JXValue {
-
-    /// Defines a property on the JavaScript object value or modifies a property’s definition.
-    ///
-    /// - Parameters:
-    ///   - property: The property's key, which can either be a string or a symbol.
-    ///   - descriptor: The descriptor object.
-    ///
-    /// - Returns: the key for the property that was defined
-    @inlinable public func defineProperty(_ property: JXValue, _ descriptor: JXProperty) throws {
-        let desc = JXValue(newObjectIn: ctx)
-
-        if let value = descriptor.value {
-            try desc.setProperty("value", value)
-        }
-
-        if let writable = descriptor.writable {
-            try desc.setProperty("writable", JXValue(bool: writable, in: ctx))
-        }
-
-        if let getter = descriptor._getter {
-            try desc.setProperty("get", getter)
-        } else if let getter = descriptor.getter {
-            try desc.setProperty("get", JXValue(newFunctionIn: ctx) { _, this, _ in try getter(this!) })
-        }
-
-        if let setter = descriptor._setter {
-            try desc.setProperty("set", setter)
-        } else if let setter = descriptor.setter {
-            try desc.setProperty("set", JXValue(newFunctionIn: ctx) { context, this, arguments in
-                try setter(this!, arguments[0])
-                return JXValue(undefinedIn: context)
-            })
-        }
-        
-        if let configurable = descriptor.configurable {
-            try desc.setProperty("configurable", JXValue(bool: configurable, in: ctx))
-        }
-
-        if let enumerable = descriptor.enumerable {
-            try desc.setProperty("enumerable", JXValue(bool: enumerable, in: ctx))
-        }
-
-        try ctx.objectPrototype.invokeMethod("defineProperty", withArguments: [self, property, desc])
-    }
-
-    public func propertyDescriptor(_ property: JXValue) throws -> JXValue {
-        try ctx.objectPrototype.invokeMethod("getOwnPropertyDescriptor", withArguments: [self, property])
-    }
-}
-
-
-// MARK: Properties
-
-/// A descriptor for property’s definition
-public struct JXProperty {
-    public let value: JXValue?
-    public let writable: Bool?
-    @usableFromInline internal let _getter: JXValue?
-    @usableFromInline internal let _setter: JXValue?
-    public let getter: ((JXValue) throws -> JXValue)?
-    public let setter: ((JXValue, JXValue) throws -> Void)?
-    public var configurable: Bool? = nil
-    public var enumerable: Bool? = nil
-
-    /// Generic Descriptor
-    ///
-    /// Contains one or both of the keys enumerable or configurable. Use a genetic descriptor to modify the attributes of an existing
-    /// data or accessor property, or to create a new data property.
-    public init() {
-        self.value = nil
-        self.writable = nil
-        self._getter = nil
-        self._setter = nil
-        self.getter = nil
-        self.setter = nil
-    }
-
-    /// Data Descriptor
-    ///
-    /// Contains one or both of the keys value and writable, and optionally also contains the keys enumerable or configurable. Use a
-    /// data descriptor to create or modify the attributes of a data property on an object (replacing any existing accessor property).
-    public init(value: JXValue? = nil, writable: Bool? = nil, configurable: Bool? = nil, enumerable: Bool? = nil) {
-        self.value = value
-        self.writable = writable
-        self._getter = nil
-        self._setter = nil
-        self.getter = nil
-        self.setter = nil
-        self.configurable = configurable
-        self.enumerable = enumerable
-    }
-
-    /// Accessor Descriptor
-    ///
-    /// Contains one or both of the keys get or set, and optionally also contains the keys enumerable or configurable. Use an accessor
-    /// descriptor to create or modify the attributes of an accessor property on an object (replacing any existing data property).
-    ///
-    /// ```
-    /// let desc = JXProperty(
-    ///     getter: { this in this["private_val"] },
-    ///     setter: { this, newValue in this["private_val"] = newValue }
-    /// )
-    /// ```
-    public init(getter: ((JXValue) throws -> JXValue)? = nil, setter: ((JXValue, JXValue) throws -> Void)? = nil, configurable: Bool? = nil, enumerable: Bool? = nil) {
-        self.value = nil
-        self.writable = nil
-        self._getter = nil
-        self._setter = nil
-        self.getter = getter
-        self.setter = setter
-        self.configurable = configurable
-        self.enumerable = enumerable
-    }
-
-    /// Accessor Descriptor
-    ///
-    /// Contains one or both of the keys get or set, and optionally also contains the keys enumerable or configurable. Use an accessor
-    /// descriptor to create or modify the attributes of an accessor property on an object (replacing any existing data property).
-    public init(getter: JXValue? = nil, setter: JXValue? = nil, configurable: Bool? = nil, enumerable: Bool? = nil) throws {
-        precondition(getter?.isFunction != false, "Invalid getter type")
-        precondition(setter?.isFunction != false, "Invalid setter type")
-        self.value = nil
-        self.writable = nil
-        self._getter = getter
-        self._setter = setter
-        self.getter = getter.map { getter in { this in try getter.call(withArguments: [], this: this) } }
-        self.setter = setter.map { setter in { this, newValue in try setter.call(withArguments: [newValue], this: this) } }
-        self.configurable = configurable
-        self.enumerable = enumerable
-    }
-}
-
-
-/// A type of JavaScript instance.
-public enum JXType : Hashable {
-    /// A boolean type.
-    case boolean
-    /// A number type.
-    case number
-    /// A date type.
-    case date
-    /// A buffer type
-    case buffer
-    /// A string type.
-    case string
-    /// An array type.
-    case array
-    /// An object type
-    case object
-    /// An symbol type
-    case symbol
-}
-
-extension JXValue {
-    @inlinable public var type: JXType? {
-        if isUndefined { return nil }
-        if isNull { return nil }
-        if isBoolean { return .boolean }
-        if isNumber { return .number }
-        if isSymbol { return .symbol }
-        if (try? isDate) == true { return .date }
-        if isString { return .string }
-        if isArray { return .array }
-        if isObject { return .object }
-        return nil
-    }
-}
-
-/// MARK: Peers
 
 extension JXValue {
     /// A peer is an instance of `AnyObject` that is created from ``JXContext.object`` with a peer argument.
@@ -1110,7 +949,7 @@ extension JXValue {
         get {
             guard isObject,
                   !isFunction,
-                  let ptr = JSObjectGetPrivate(value) else {
+                  let ptr = JSObjectGetPrivate(valueRef) else {
                 return nil
             }
             return ptr.assumingMemoryBound(to: AnyObject?.self).pointee

--- a/Sources/JXKit/Module.swift
+++ b/Sources/JXKit/Module.swift
@@ -3,8 +3,6 @@ import class Foundation.NSDictionary
 
 // This class supports extracting the version information of the runtime.
 
-// MARK: JXKit Module Metadata
-
 /// The bundle for the `JXKit` module.
 public let JXKitBundle = Foundation.Bundle.module
 

--- a/Tests/JXKitTests/JXCodableTests.swift
+++ b/Tests/JXKitTests/JXCodableTests.swift
@@ -94,14 +94,14 @@ final class JXCodableTests: XCTestCase {
     func testCodableData() throws {
         let jxc = JXContext()
         let dataValue = try jxc.encode(Data([1,2,3,4]))
-        XCTAssertEqual("[object ArrayBuffer]", try dataValue.stringValue)
-        XCTAssertEqual(4, try dataValue["byteLength"].numberValue)
+        XCTAssertEqual("[object ArrayBuffer]", try dataValue.string)
+        XCTAssertEqual(4, try dataValue["byteLength"].int)
     }
 
     func testCodableDate() throws {
         let jxc = JXContext()
-        let dateValue = try jxc.encode(Date(timeIntervalSince1970: 1234))
-        XCTAssertEqual("Thu, 01 Jan 1970 00:20:34 GMT", try dateValue.invokeMethod("toGMTString", withArguments: []).stringValue)
+        let date = try jxc.encode(Date(timeIntervalSince1970: 1234))
+        XCTAssertEqual("Thu, 01 Jan 1970 00:20:34 GMT", try date.invokeMethod("toGMTString", withArguments: []).string)
     }
 
     /// An example of invoking `Math.hypot` directly with numeric arguments
@@ -110,13 +110,13 @@ final class JXCodableTests: XCTestCase {
         let hypot = try jxc.global["Math"]["hypot"]
         XCTAssert(hypot.isFunction)
         let result = try hypot.call(withArguments: try [jxc.encode(3), jxc.encode(4)])
-        XCTAssertEqual(5, try result.numberValue)
+        XCTAssertEqual(5, try result.int)
     }
 
     /// An example of invoking `Math.hypot` in a wrapper function that takes an encodable argument and returns a Decodable retult.
     func testCodableParamObject() throws {
-        struct AB : Encodable { let a, b: Double }
-        struct C : Decodable { let c: Double }
+        struct AB: Encodable { let a, b: Double }
+        struct C: Decodable { let c: Double }
 
         let jxc = JXContext()
         let hypot = try jxc.eval("(function(args) { return { c: Math.hypot(args.a, args.b) }; })")
@@ -130,8 +130,8 @@ final class JXCodableTests: XCTestCase {
         let jxc = JXContext()
         let jsfib = try jxc.eval("(function fibo(x) { if (x<=2) return 1; else return fibo(x-1) + fibo(x-2) })")
 
-        func fib(_ n: Int) throws -> Double {
-            try jsfib.call(withArguments: [jxc.number(n)]).numberValue
+        func fib(_ n: Int) throws -> Int {
+            try jsfib.call(withArguments: [jxc.number(n)]).int
         }
 
         XCTAssertEqual(3, try fib(4))
@@ -186,16 +186,16 @@ final class JXCodableTests: XCTestCase {
         let jxc = JXContext()
 
         let htpy = JXValue(newFunctionIn: jxc) { jxc, this, args in
-            jxc.number(try sqrt(pow(args.first?["x"].numberValue ?? 0.0, 2) + pow(args.first?["y"].numberValue ?? 0.0, 2)))
+            jxc.number(try sqrt(pow(args.first?["x"].double ?? 0.0, 2) + pow(args.first?["y"].double ?? 0.0, 2)))
         }
 
-        struct Args : Encodable {
+        struct Args: Encodable {
             let x: Int16
             let y: Float
         }
 
         func hfun(_ args: Args) throws -> Double? {
-            try htpy.call(withArguments: [try jxc.encode(args)]).numberValue
+            try htpy.call(withArguments: [try jxc.encode(args)]).double
         }
 
         XCTAssertEqual(5, try hfun(Args(x: 3, y: 4)))

--- a/Tests/JXKitTests/JXCoreTests.swift
+++ b/Tests/JXKitTests/JXCoreTests.swift
@@ -27,7 +27,7 @@ class JXCoreTests: XCTestCase {
     func testFunction1() throws {
         let jxc = JXContext()
         let myFunction = JXValue(newFunctionIn: jxc) { jxc, this, arguments in
-            jxc.number(try arguments[0].numberValue + arguments[1].numberValue)
+            jxc.number(try arguments[0].int + arguments[1].int)
         }
 
         XCTAssertTrue(myFunction.isFunction)
@@ -35,13 +35,13 @@ class JXCoreTests: XCTestCase {
         let result = try myFunction.call(withArguments: [jxc.number(1), jxc.number(2)])
 
         XCTAssertTrue(result.isNumber)
-        XCTAssertEqual(try result.numberValue, 3)
+        XCTAssertEqual(try result.int, 3)
     }
 
     func testFunction2() throws {
         let jxc = JXContext()
         let myFunction = JXValue(newFunctionIn: jxc) { jxc, this, arguments in
-            jxc.number(try arguments[0].numberValue + arguments[1].numberValue)
+            jxc.number(try arguments[0].int + arguments[1].int)
         }
 
         XCTAssertTrue(myFunction.isFunction)
@@ -50,13 +50,13 @@ class JXCoreTests: XCTestCase {
         let result = try jxc.eval("myFunction(1, 2)")
 
         XCTAssertTrue(result.isNumber)
-        XCTAssertEqual(try result.numberValue, 3)
+        XCTAssertEqual(try result.int, 3)
     }
 
     func testFunctionError() throws {
         let jxc = JXContext()
 
-        enum CustomError : Error {
+        enum CustomError: Error {
             case someError
         }
 
@@ -84,7 +84,7 @@ class JXCoreTests: XCTestCase {
         let result = try jxc.eval("1 + 1")
 
         XCTAssertTrue(result.isNumber)
-        XCTAssertEqual(try result.numberValue, 2)
+        XCTAssertEqual(try result.int, 2)
     }
 
     func testArray() throws {
@@ -95,11 +95,11 @@ class JXCoreTests: XCTestCase {
         XCTAssertTrue(result.isArray)
 
         let length = try result["length"]
-        XCTAssertEqual(try length.numberValue, 3)
+        XCTAssertEqual(try length.int, 3)
 
-        XCTAssertEqual(try result[0].numberValue, 3)
-        XCTAssertEqual(try result[1].stringValue, "BMW")
-        XCTAssertEqual(try result[2].stringValue, "Volvo")
+        XCTAssertEqual(try result[0].int, 3)
+        XCTAssertEqual(try result[1].string, "BMW")
+        XCTAssertEqual(try result[2].string, "Volvo")
     }
 
     func testGetter() throws {
@@ -113,7 +113,7 @@ class JXCoreTests: XCTestCase {
 
         try jxc.global["obj"].defineProperty(jxc.string("three"), desc)
         let result = try jxc.eval("obj.three")
-        XCTAssertEqual(try result.numberValue, 3)
+        XCTAssertEqual(try result.int, 3)
     }
 
     func testSetter() throws {
@@ -130,19 +130,19 @@ class JXCoreTests: XCTestCase {
 
         try jxc.eval("obj.number = 5")
 
-        XCTAssertEqual(try jxc.global["obj"]["number"].numberValue, 5)
-        XCTAssertEqual(try jxc.global["obj"]["number_container"].numberValue, 5)
+        XCTAssertEqual(try jxc.global["obj"]["number"].int, 5)
+        XCTAssertEqual(try jxc.global["obj"]["number_container"].int, 5)
 
         try jxc.eval("obj.number = 3")
 
-        XCTAssertEqual(try jxc.global["obj"]["number"].numberValue, 3)
-        XCTAssertEqual(try jxc.global["obj"]["number_container"].numberValue, 3)
+        XCTAssertEqual(try jxc.global["obj"]["number"].int, 3)
+        XCTAssertEqual(try jxc.global["obj"]["number_container"].int, 3)
     }
 
     func testSymbols() throws {
         let jxc = JXContext()
 
-        let obj = jxc.symbol("obj") // the unique symbol for the object
+        let obj = jxc.symbol("obj") // The unique symbol for the object
 
         XCTAssertEqual(true, try jxc.global[symbol: obj].isUndefined)
         try jxc.global.setProperty(symbol: obj, jxc.object())
@@ -169,12 +169,12 @@ class JXCoreTests: XCTestCase {
 
         try jxc.eval("this[object_symbol].number = 5")
 
-        XCTAssertEqual(try gobj["number"].numberValue, 5)
+        XCTAssertEqual(try gobj["number"].int, 5)
 
         try jxc.eval("this[object_symbol].number = 3")
 
-        XCTAssertEqual(try jxc.global[symbol: obj]["number"].numberValue, 3)
-        //XCTAssertEqual(try jxc.global[symbol: obj][symbol: container].numberValue, 3)
+        XCTAssertEqual(try jxc.global[symbol: obj]["number"].int, 3)
+        //XCTAssertEqual(try jxc.global[symbol: obj][symbol: container].int, 3)
     }
 
     func testArrayBuffer() throws {
@@ -198,9 +198,9 @@ class JXCoreTests: XCTestCase {
                 return XCTFail("failed")
             }
             XCTAssertEqual(true, isView.isBoolean)
-            XCTAssertEqual(false, isView.booleanValue)
+            XCTAssertEqual(false, isView.bool)
 
-            XCTAssertEqual(.init(bufferSize), try? arrayBuffer["byteLength"].numberValue)
+            XCTAssertEqual(.init(bufferSize), try? arrayBuffer["byteLength"].int)
         }
     }
     
@@ -209,7 +209,7 @@ class JXCoreTests: XCTestCase {
 
         do {
             let vm = JXVM()
-            let jxc = JXContext(virtualMachine: vm)
+            let jxc = JXContext(vm: vm)
             var bytes: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8]
 
             try bytes.withUnsafeMutableBytes { bytes in
@@ -235,9 +235,9 @@ class JXCoreTests: XCTestCase {
 
         measure { // average: 0.000, relative standard deviation: 99.521%, values: [0.000434, 0.000037, 0.000959, 0.000050, 0.000471, 0.000048, 0.000394, 0.000048, 0.000389, 0.000047]
             let result: Double? = try? jxc.withArrayBuffer(source: data) { buffer in
-                XCTAssertEqual(true, try buffer["byteLength"].booleanValue)
+                XCTAssertEqual(true, try buffer["byteLength"].bool)
                 XCTAssertEqual(true, try buffer["slice"].isFunction)
-                return try buffer["byteLength"].numberValue
+                return try buffer["byteLength"].double
             }
             XCTAssertEqual(Double?.some(.init(size)), result)
         }
@@ -267,7 +267,7 @@ class JXCoreTests: XCTestCase {
         let jxc = JXContext()
 
         let myClass = JXValue(newFunctionIn: jxc) { jxc, this, arguments in
-            let result = try arguments[0].numberValue + arguments[1].numberValue
+            let result = try arguments[0].int + arguments[1].int
             let object = jxc.object()
             try object.setProperty("result", jxc.number(result))
 
@@ -281,7 +281,7 @@ class JXCoreTests: XCTestCase {
         let result = try jxc.eval("new myClass(1, 2)")
 
         XCTAssertTrue(result.isObject)
-        XCTAssertEqual(try result["result"].numberValue, 3)
+        XCTAssertEqual(try result["result"].int, 3)
 
         XCTAssertTrue(try result.isInstance(of: myClass))
     }
@@ -291,7 +291,7 @@ class JXCoreTests: XCTestCase {
 
         do {
             try jxc.global.setProperty("setTimeout", JXValue(newFunctionIn: jxc) { jxc, this, args in
-                print("setTimeout", try args.map({ try $0.stringValue }))
+                print("setTimeout", try args.map({ try $0.string }))
                 return jxc.number(0)
             })
 
@@ -306,18 +306,18 @@ class JXCoreTests: XCTestCase {
                 arr.push(2);
                 """)
 
-            XCTAssertGreaterThan(try result.numberValue, 0)
+            XCTAssertGreaterThan(try result.int, 0)
 
             // this appears to be fixed in macOS 13 and iOS 15
             // Bug 161942: Shouldn't drain the micro task queue when calling out
             // https://developer.apple.com/forums/thread/678277
 
             if #available(macOS 12, iOS 15, tvOS 15, *) {
-                XCTAssertEqual(2, try result.numberValue)
-                XCTAssertEqual([1.0, 2.0, 3.0], try jxc.global["arr"].array.map({ try $0.numberValue }))
+                XCTAssertEqual(2, try result.int)
+                XCTAssertEqual([1, 2, 3], try jxc.global["arr"].array.map({ try $0.int }))
             } else {
-                XCTAssertEqual(3, try result.numberValue)
-                XCTAssertEqual([1.0, 3.0, 2.0], try jxc.global["arr"].array.map({ try $0.numberValue }))
+                XCTAssertEqual(3, try result.int)
+                XCTAssertEqual([1, 3, 2], try jxc.global["arr"].array.map({ try $0.int }))
             }
         }
 
@@ -326,7 +326,7 @@ class JXCoreTests: XCTestCase {
             let resolvedPromise = try JXValue(newPromiseResolvedWithResult: jxc.string(str), in: jxc)
             try jxc.global.setProperty("prm", resolvedPromise)
             let _ = try jxc.eval("(async () => { this['cb'] = await prm; })();")
-            XCTAssertEqual(str, try jxc.global["cb"].stringValue)
+            XCTAssertEqual(str, try jxc.global["cb"].string)
         }
     }
 
@@ -347,7 +347,7 @@ class JXCoreTests: XCTestCase {
             XCTAssertEqual("TypeError: function is not a constructor (evaluating 'new Symbol('xxx')')", "\(error)")
         }
 
-        XCTAssertThrowsError(try jxc.eval("Symbol('xxx')").stringValue) { error in
+        XCTAssertThrowsError(try jxc.eval("Symbol('xxx')").string) { error in
             XCTAssertEqual("TypeError: Cannot convert a symbol to a string", "\(error)")
         }
 
@@ -372,7 +372,7 @@ class JXCoreTests: XCTestCase {
                 try jxc.eval(script)
                 return nil
             } catch let error as JXError {
-                return try error.stringValue
+                return try error.string
             } catch {
                 XCTFail("unexpected error type: \(error)")
                 return nil
@@ -388,7 +388,7 @@ class JXCoreTests: XCTestCase {
         XCTAssertEqual(try lint("1["), "SyntaxError: Unexpected end of script")
         XCTAssertEqual(try lint("1]"), "SyntaxError: Unexpected token \']\'. Parse error.")
 
-        // strict checks
+        // Strict checks
 
         XCTAssertEqual(try lint("use strict"), "SyntaxError: Unexpected identifier \'strict\'") // need to quote
         XCTAssertEqual(try lint("'use strict'\nmistypeVarible = 17"), "ReferenceError: Can\'t find variable: mistypeVarible")

--- a/Tests/JXKitTests/JXKitTests.swift
+++ b/Tests/JXKitTests/JXKitTests.swift
@@ -5,7 +5,7 @@ final class JXKitTests: XCTestCase {
     func testAPI() throws {
         let jxc = JXContext()
         let value: JXValue = try jxc.eval("1+2")
-        XCTAssertEqual(3, try value.numberValue)
+        XCTAssertEqual(3, try value.int)
     }
 
     /// https://www.destroyallsoftware.com/talks/wat
@@ -13,24 +13,24 @@ final class JXKitTests: XCTestCase {
         let jxc = JXContext()
 
         XCTAssertEqual(true, try jxc.eval("[] + {}").isString)
-        XCTAssertEqual("[object Object]", try jxc.eval("[] + {}").stringValue)
+        XCTAssertEqual("[object Object]", try jxc.eval("[] + {}").string)
 
         XCTAssertEqual(true, try jxc.eval("[] + []").isString)
-        XCTAssertEqual("", try jxc.eval("[] + []").stringValue)
+        XCTAssertEqual("", try jxc.eval("[] + []").string)
 
         XCTAssertEqual(true, try jxc.eval("{} + {}").isNumber)
-        XCTAssertEqual(true, try jxc.eval("{} + {}").numberValue.isNaN)
+        XCTAssertEqual(true, try jxc.eval("{} + {}").double.isNaN)
 
         XCTAssertEqual(true, try jxc.eval("{} + []").isNumber)
-        XCTAssertEqual(0.0, try jxc.eval("{} + []").numberValue)
+        XCTAssertEqual(0.0, try jxc.eval("{} + []").double)
 
-        XCTAssertEqual(true, try jxc.eval("1.0 === 1.0000000000000001").booleanValue)
+        XCTAssertEqual(true, try jxc.eval("1.0 === 1.0000000000000001").bool)
 
         XCTAssertEqual(1, try jxc.eval("let y = {}; y[[]] = 1; Object.keys(y)").array.count)
 
-        XCTAssertEqual(10, try jxc.eval("['10', '10', '10'].map(parseInt)").array.first?.numberValue)
-        XCTAssertEqual("NaN", try jxc.eval("['10', '10', '10'].map(parseInt)").array.dropFirst().first?.stringValue)
-        XCTAssertEqual(2, try jxc.eval("['10', '10', '10'].map(parseInt)").array.last?.numberValue)
+        XCTAssertEqual(10, try jxc.eval("['10', '10', '10'].map(parseInt)").array.first?.double)
+        XCTAssertEqual("NaN", try jxc.eval("['10', '10', '10'].map(parseInt)").array.dropFirst().first?.string)
+        XCTAssertEqual(2, try jxc.eval("['10', '10', '10'].map(parseInt)").array.last?.double)
     }
 }
 


### PR DESCRIPTION
- Add spi properties.
- Consistently append "Ref" to C-type var names.
- Consistently call JXContext params and vars "context".
- Consistently call JXVM params and vars "vm".
- Change makeJX/getJX to fromJX/toJX for clarity.
- Change JXValue.xxxValue vars to instead be named for the Swift type they return, and add primitive common types. Reasoning: these vars exist to retrieve native Swift values for the represented JS value, and no reason to make users do number conversions from Double, etc themselves.
- Add "null", "undefined", "other" cases to JXType and make JXValue.type non-Optional. Reasoning: I just fine optional enums strange and haven't seen that pattern much.
- Remove JXValueError as I couldn't see anywhere it was created.
- Rename JXError to JXEvalError to make use case vs. JXErrors more clear.
- Move some types to their own files.
- Remove file headers as they repeated comments in the file.
- Remove MARK: directives as they were inconsistently used.
- Make JXCoding file code style consistent with other files.
- Make comments capitalization and use of Parameters: consistent.