### PR TITLE
Enhance support for type bridging:

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ let hypot = try context.global["Math"]["hypot"]
 assert(hypot.isFunction == true)
 let result = try hypot.call(withArguments: try [context.encode(3), context.encode(4)])
 let hypotValue = try result.double
-assert(hypotValue == 5)
+assert(hypotValue == 5.0)
 ```
 
 ### Codable passing
@@ -62,7 +62,7 @@ import JavaScriptCore
 
 let jsc = JSContext()
 let value: JSValue = jsc.evaluateScript("1+2")
-assert(value.doubleValue == 3)
+assert(value.int == 3)
 ```
 
 becomes:

--- a/Sources/JXKit/JXErrors.swift
+++ b/Sources/JXKit/JXErrors.swift
@@ -8,27 +8,31 @@ public enum JXErrors: Error {
     case cannotCreatePromise
     /// Unable to create a new array buffer.
     case cannotCreateArrayBuffer
-    /// An async call is expected to return a promise.
-    case asyncEvalMustReturnPromise
-    /// The promise returned from an async call is not value.
-    case invalidAsyncPromise
-    /// Attempt to invoke a non-function object.
-    case callOnNonFunction
-    /// Attempt to access a property on an instance that is not an object.
-    case propertyAccessNonObject
-    /// Attempt to add to something that is not an array.
-    case addToNonArray
-    /// This can occur when the bound instance is not retained anywhere.
-    case jumpContextInvalid
-    /// Expected an array for conversion.
-    case valueNotArray
-    /// Expected a date for conversion.
-    case valueNotDate
-    /// A synbolic key was attempted to be set, but the value was not a symbol.
-    case keyNotSymbol
     /// An object could not be created from the given JSON.
     case cannotCreateFromJSON
-    /// A conversion to another numic type failed.
+    /// Cannot convey this type to or from JavaScript.
+    case cannotConvey(Any.Type)
+    /// An async call is expected to return a promise.
+    case asyncEvalMustReturnPromise
+    /// The promise returned from an async call is not valid.
+    case invalidAsyncPromise
+    /// A conversion to another numic type or min/max range failed.
     case invalidNumericConversion(Double)
+    /// A value could not be used to create a `RawRepresentable`.
+    case invalidRawValue(String)
+    /// A synbolic key was attempted to be set, but the value was not a symbol.
+    case keyNotSymbol
+    /// This can occur when the bound instance is not retained anywhere.
+    case jumpContextInvalid
+    /// Expected a JavaScript array.
+    case valueNotArray
+    /// Expected a JavaScript date.
+    case valueNotDate
+    /// Expected a JavaScript function.
+    case valueNotFunction
+    /// Expected a JavaScript number.
+    case valueNotNumber
+    /// Expected a JavaScript object.
+    case valueNotObject
 }
 

--- a/Sources/JXKit/JXVM.swift
+++ b/Sources/JXKit/JXVM.swift
@@ -25,9 +25,6 @@ public final class JXVM {
         JSContextGroupRetain(groupRef)
     }
 
-    /// For use by service providers only.
-    public var spi: AnyObject?
-
     deinit {
         JSContextGroupRelease(groupRef)
     }


### PR DESCRIPTION
- Add API for getting a JXValue as any base numeric type.
  - Note that getting a NaN/Infinity value as an Integer type now throws.
- Add JXConvertible conformance to all base types (from Jack).
  - Note that I changed the numeric types to use above JXValue.xxx code path for their fromJX implementations.
- Add JXConvertible conformance to [String: JXConvertible] and add JXContext.object(fromDictionary:) as symmetric with existing JXValue.dictionary.
- Change JXValue.convey():
  - Can attempt to convey() to any type, not just JXConvertible types.
  - Falls back to using Codable when type is not JXConvertible.
  - If context.spi has been set, ask SPI to convey any non-JXConvertible types before we try to use Codable.
- Add JXContext.convey() as analog to JXValue.convey() for creating a JXValue from any value.
  - Similar behavior: if context.spi has been set, ask SPI to convey non- JXConvertible types, then fall back to Codable.
- Generalize some of the JXErrors a bit.
- Make previously-internal APIs for adding and inserting into a JXValue representing an array public - because why not?