### PR TITLE
Fix SPI method type signature

### DIFF
--- a/Sources/JXKit/JXContext.swift
+++ b/Sources/JXKit/JXContext.swift
@@ -386,12 +386,12 @@ extension JXContext {
 
 /// Optional service provider integration points.
 public protocol JXContextSPI {
-    func toJX<T>(_ value: T, in context: JXContext) throws -> JXValue?
+    func toJX(_ value: Any, in context: JXContext) throws -> JXValue?
     func fromJX<T>(_ value: JXValue, to type: T.Type) throws -> T?
 }
 
 extension JXContextSPI {
-    public func toJX<T>(_ value: T, in context: JXContext) throws -> JXValue? {
+    public func toJX(_ value: Any, in context: JXContext) throws -> JXValue? {
         return nil
     }
 


### PR DESCRIPTION
Using a <T> generic is preventing type(of:) from returning the dynamic type. Also the type T is not actually known at the call site; it will always be Any.