### PR TITLE
Add convenience API using convey().

### DIFF
--- a/Sources/JXKit/JXContext.swift
+++ b/Sources/JXKit/JXContext.swift
@@ -90,10 +90,13 @@ extension JXContext {
         }
 
         let script = script.withCString(JSStringCreateWithUTF8CString)
+
         defer { JSStringRelease(script) }
+
         let result = try trying {
             JSEvaluateScript(contextRef, script, this?.valueRef, nil, 0, $0)
         }
+
         return result.map { JXValue(context: self, valueRef: $0) } ?? JXValue(undefinedIn: self)
     }
 
@@ -101,9 +104,6 @@ extension JXContext {
     ///
     /// The script is expected to return a `Promise` either directly or through the implicit promise
     /// that is created in async calls.
-    ///
-    /// - Parameters:
-    ///   - arguments: Arguments to make available to the executing JavaScript as vars with names '$0, $1, ...'.
     @discardableResult public func eval(_ script: String, this: JXValue? = nil, priority: TaskPriority) async throws -> JXValue {
         let promise = try eval(script, this: this)
         guard try promise.isPromise else {

--- a/Sources/JXKit/JXValue.swift
+++ b/Sources/JXKit/JXValue.swift
@@ -574,7 +574,7 @@ extension JXValue {
     /// Calls an object as a function.
     ///
     /// - Parameters:
-    ///   - arguments: The arguments pass to the function.
+    ///   - arguments: The arguments to pass to the function.
     ///   - this: The object to use as `this`, or `nil` to use the global object as `this`.
     /// - Returns: The object that results from calling object as a function
     @discardableResult @inlinable public func call(withArguments arguments: [JXValue] = [], this: JXValue? = nil) throws -> JXValue {
@@ -591,27 +591,60 @@ extension JXValue {
         } ?? JXValue(undefinedIn: context)
     }
 
+    /// Calls an object as a function.
+    ///
+    /// - Parameters:
+    ///   - arguments: The arguments to pass to the function. The arguments will be `conveyed` to `JXValues`.
+    ///   - this: The object to use as `this`, or `nil` to use the global object as `this`.
+    /// - Returns: The object that results from calling object as a function
+    @discardableResult @inlinable public func call(withArguments arguments: [Any], this: JXValue? = nil) throws -> JXValue {
+        let jxarguments = try arguments.map { try context.convey($0) }
+        return try call(withArguments: jxarguments, this: this)
+    }
+
     /// Calls an object as a constructor.
     ///
     /// - Parameters:
-    ///   - arguments: The arguments pass to the function.
+    ///   - arguments: The arguments to pass to the function.
     /// - Returns: The object that results from calling object as a constructor.
-    @inlinable public func construct(withArguments arguments: [JXValue]) throws -> JXValue {
+    @inlinable public func construct(withArguments arguments: [JXValue] = []) throws -> JXValue {
         let result = try context.trying {
             JSObjectCallAsConstructor(context.contextRef, valueRef, arguments.count, arguments.isEmpty ? nil : arguments.map { $0.valueRef }, $0)
         }
         return result.map { JXValue(context: context, valueRef: $0) } ?? JXValue(undefinedIn: context)
     }
 
+    /// Calls an object as a constructor.
+    ///
+    /// - Parameters:
+    ///   - arguments: The arguments to pass to the function. The arguments will be `conveyed` to `JXValues`.
+    /// - Returns: The object that results from calling object as a constructor.
+    @inlinable public func construct(withArguments arguments: [Any]) throws -> JXValue {
+        let jxarguments = try arguments.map { try context.convey($0) }
+        return try construct(withArguments: jxarguments)
+    }
+
     /// Invoke an object's method.
     ///
     /// - Parameters:
-    ///   - name: The name of method.
-    ///   - arguments: The arguments pass to the function.
+    ///   - name: The name of the method.
+    ///   - arguments: The arguments to pass to the function.
     /// - Returns: The object that results from calling the method.
     @discardableResult
-    @inlinable public func invokeMethod(_ name: String, withArguments arguments: [JXValue]) throws -> JXValue {
+    @inlinable public func invokeMethod(_ name: String, withArguments arguments: [JXValue] = []) throws -> JXValue {
         try self[name].call(withArguments: arguments, this: self)
+    }
+
+    /// Invoke an object's method.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the method.
+    ///   - arguments: The arguments to pass to the function. The arguments will be `conveyed` to `JXValues`.
+    /// - Returns: The object that results from calling the method.
+    @discardableResult
+    @inlinable public func invokeMethod(_ name: String, withArguments arguments: [Any]) throws -> JXValue {
+        let jxarguments = try arguments.map { try context.convey($0) }
+        return try invokeMethod(name, withArguments: jxarguments)
     }
 }
 
@@ -746,9 +779,9 @@ extension JXValue {
     /// Sets the property of the object to the given value.
     ///
     /// - Parameters:
-    ///   - key: the key name to set
-    ///   - newValue: the value of the property
-    /// - Returns: the value itself
+    ///   - key: The key name to set.
+    ///   - newValue: The value of the property.
+    /// - Returns: The value itself.
     @discardableResult @inlinable public func setProperty(_ key: String, _ newValue: JXValue) throws -> JXValue {
         if !isObject {
             throw JXErrors.valueNotObject
@@ -762,12 +795,22 @@ extension JXValue {
         return newValue
     }
 
+    /// Sets the property of the object to the given value.
+    ///
+    /// - Parameters:
+    ///   - key: The key name to set.
+    ///   - newValue: The value of the property. The value will be `conveyed` to a `JXValue`.
+    /// - Returns: The value itself.
+    @discardableResult @inlinable public func setProperty(_ key: String, _ newValue: Any) throws -> JXValue {
+        return try setProperty(key, context.convey(newValue))
+    }
+
     /// Sets the property specified by the symbol key.
     ///
     /// - Parameters:
-    ///   - key: the name of the symbol to use
-    ///   - newValue: the value to set the property
-    /// - Returns: the value itself
+    ///   - key: The name of the symbol to use.
+    ///   - newValue: The value to set the property.
+    /// - Returns: The value itself.
     @discardableResult @inlinable public func setProperty(symbol: JXValue, _ newValue: JXValue) throws -> JXValue {
         if !isObject {
             throw JXErrors.valueNotObject
@@ -777,6 +820,16 @@ extension JXValue {
             JSObjectSetPropertyForKey(context.contextRef, valueRef, symbol.valueRef, newValue.valueRef, 0, $0)
         }
         return newValue
+    }
+
+    /// Sets the property specified by the symbol key.
+    ///
+    /// - Parameters:
+    ///   - key: The name of the symbol to use.
+    ///   - newValue: The value to set the property. The value will be `conveyed` to a `JXValue`.
+    /// - Returns: The value itself.
+    @discardableResult @inlinable public func setProperty(symbol: JXValue, _ newValue: Any) throws -> JXValue {
+        return try setProperty(symbol: symbol, context.convey(newValue))
     }
 }
 
@@ -805,9 +858,19 @@ extension JXValue {
         }
     }
 
+    /// Set an element of this array, overwriting any previous element.
+    @inlinable public func setElement(_ element: Any, at index: Int) throws {
+        try setElement(context.convey(element), at: index)
+    }
+
     /// Adds the given object as the final element of this array.
     @inlinable public func addElement(_ object: JXValue) throws {
-        try self.setElement(object, at: count)
+        try setElement(object, at: count)
+    }
+
+    /// Adds the given object as the final element of this array.
+    @inlinable public func addElement(_ object: Any) throws {
+        try addElement(context.convey(object))
     }
 
     /// Inserts the given object into this array, shifting subsequent elements.
@@ -816,6 +879,11 @@ extension JXValue {
             try setElement(self[i-1], at: i) // Shift all the latter elements up by one
         }
         try setElement(object, at: index) // And fill in the index (JS permits assigning a non-existent index)
+    }
+
+    /// Inserts the given object into this array, shifting subsequent elements.
+    @inlinable public func insertElement(_ object: Any, at index: Int) throws {
+        try insertElement(context.convey(object), at: index)
     }
 }
 

--- a/Tests/JXKitTests/JXCoreTests.swift
+++ b/Tests/JXKitTests/JXCoreTests.swift
@@ -535,15 +535,22 @@ class JXCoreTests: XCTestCase {
         XCTAssertEqual(0, try emptyarray.count)
     }
 
-    func testEvalWithArguments() throws {
+    func testWithValues() throws {
         let jxc = JXContext()
-        var result = try jxc.eval("$0 + $1", withArguments: [1, 2])
+        var result = try jxc.withValues([1, 2]) { try jxc.eval("$0 + $1") }
         XCTAssertEqual(try result.int, 3)
         XCTAssertTrue(try jxc.global["$0"].isUndefined)
         XCTAssertTrue(try jxc.global["$1"].isUndefined)
 
-        result = try jxc.eval("$0 + $1 + $2", withArguments: ["a", 1, "c"])
+        result = try jxc.withValues("a", 1, "c") { try jxc.eval("$0 + $1 + $2") }
         XCTAssertEqual(try result.string, "a1c")
+
+        do {
+            let _ = try jxc.withValues(1) { try jxc.eval("*= $0") }
+            XCTFail("eval should have thrown syntax error")
+        } catch {
+            XCTAssertTrue(try jxc.global["$0"].isUndefined)
+        }
     }
 
     func testNew() throws {


### PR DESCRIPTION
- Whenever an API has a JXValue/[JXValue] param that typically expects representations of native values/objects, add an equivalent API with an Any/[Any] param that is auto-converted to JXValue(s) using convey().
- Add an optional withArguments: param to JXContext.eval that allows you to pass in values that will be available as global vars during the eval. The vars are named $0, $1, ... after Swift's closure param names.
- Add funcs that can create new JS class instances.

Open questions:
- As always, please push back on *anything* in this patch.
- Is it worth keeping both the JXValue and Any versions of all these functions? The Any version would suffice because JXValues already convey() to themselves. It's less efficient to always have to test each value's type to convey() properly, but the cost of the convey is likely minor compared to the JSCore operations themselves.
- I don't understand the optional "this" param to eval(). Should the vars we create be properties on the given "this" when one is supplied?
- Should we also overload the funcs that take [JXValue] or [Any] with variadic argument versions? E.g.: jxc.eval("$0 + $1 + $2", withArguments: 100, 200, 300) It'd be nice but its a lot of overloads.